### PR TITLE
i dont even know if this is necessary.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ All programs are available as is. They might be incorrect, they might be outdate
 
 [Intellij IDEA keyword sets](https://github.com/gnembon/fabric-carpet/blob/master/docs/scarpet/resources/editors/idea/)
 
+[Vscode Autocompletion](https://github.com/imurx/vscode-scarpet)
+
 ## Changelog
 
 ### v1.6


### PR DESCRIPTION
Heck, you could just move the scarpet apps to the fabric-carpet repo to save yourself some work. Just put the programs directory next to the docs, or even better, just rename the docs folder to scarpet, and then rename the internal one from scarpet to docs, and next to it put the programs directory from here, saving yourself a lot of work going back and forth.
You should just make the readme a wiki page. In fact, lemme do that