### PR TITLE
Corrected grammar in cam.sc

### DIFF
--- a/programs/survival/cam.sc
+++ b/programs/survival/cam.sc
@@ -160,6 +160,6 @@ __survival_defaults(player) ->
          )
       )
    );
-   print(format('rb Cannot find a safe spot to land within 32 blocks away'));
+   print(format('rb Cannot find a safe spot to land within 32 blocks.'));
    false;
 );


### PR DESCRIPTION
'within 32 blocks' is enough. The away isn't need.
Also added full stop/period.