### PR TITLE
Added stay loaded to all survival programs

### DIFF
--- a/programs/survival/README.md
+++ b/programs/survival/README.md
@@ -199,4 +199,5 @@ Various scripts that modify various game elements, often replicating popular mod
 	indoorjetpacks
 	rv3r
 	RubberDuck55
+	TheCatSaber
 	(Many more hopefully!)

--- a/programs/survival/angel_block.sc
+++ b/programs/survival/angel_block.sc
@@ -1,6 +1,13 @@
 // Reimplementation of Angel Blocks from RandomThings mod in scarpet 1.4
 // By "Pegasus Epsilon" <pegasus@pimpninjas.org>
 
+// stay loaded
+__config() -> (
+   m(
+      l('stay_loaded','true')
+   )
+);
+
 // specify your preferred angel block here
 global_angel_block = block('bedrock');
 

--- a/programs/survival/auto_lighter.sc
+++ b/programs/survival/auto_lighter.sc
@@ -5,6 +5,13 @@
 
 ///right click on a torch while looking at nothing to toggle.
 
+// stay loaded
+__config() -> (
+   m(
+      l('stay_loaded','true')
+   )
+);
+
 __on_player_uses_item(player, item, hand) ->
 (
 	if (hand != 'mainhand', return());

--- a/programs/survival/auto_pickup.sc
+++ b/programs/survival/auto_pickup.sc
@@ -1,3 +1,10 @@
+// stay loaded
+__config() -> (
+   m(
+      l('stay_loaded','true')
+   )
+);
+
 // seems like drops are generated later, before the callback is made
 // so we execute moving items at the end of the tick
 __on_player_breaks_block(player, block) -> 

--- a/programs/survival/bridge_maker.sc
+++ b/programs/survival/bridge_maker.sc
@@ -2,8 +2,19 @@
 //Video: https://youtu.be/6QxQXymqRoA
 //By: Ghoulboy and Aplet123
 
-__config()->{'scope'->'player'};//So that you can't accidentlly load it in global mode and mess it up
+__config() ->
 
+(
+
+	m(
+
+		l('stay_loaded', true),
+
+		l('scope', 'player') //So that you can't accidentlly load it in global mode and mess it up
+
+		)
+
+);
 //Global variables
 
 global_bridge_tool='golden_sword';

--- a/programs/survival/drop_heads.sc
+++ b/programs/survival/drop_heads.sc
@@ -1,5 +1,12 @@
 //A Balanced way to get player heads in survival.
 
+// stay loaded
+__config() -> (
+   m(
+      l('stay_loaded','true')
+   )
+);
+
 __on_player_dies(player) -> (
   if(rand(1) <= 0.3,
     xv = rand(0.5)-0.25;

--- a/programs/survival/easier_renewable_sponge.sc
+++ b/programs/survival/easier_renewable_sponge.sc
@@ -1,6 +1,13 @@
 //killing one of each type of fish gives a random chance to get sponge
 //By: Ghoulboy
 
+// stay loaded
+__config() -> (
+   m(
+      l('stay_loaded','true')
+   )
+);
+
 global_debug=false;//for debugging purposes only
 
 __on_player_attacks_entity(player,entity)->(

--- a/programs/survival/hammer.sc
+++ b/programs/survival/hammer.sc
@@ -1,5 +1,12 @@
 //!scarpet v1.5
 
+// stay loaded
+__config() -> (
+   m(
+      l('stay_loaded','true')
+   )
+);
+
 __get_block_range(position, face) -> 
 (
 	l(x,y,z) = position;

--- a/programs/survival/holy_hand_grenades.sc
+++ b/programs/survival/holy_hand_grenades.sc
@@ -1,4 +1,12 @@
 //!scarpet 1.5
+
+// stay loaded
+__config() -> (
+   m(
+      l('stay_loaded','true')
+   )
+);
+
 __holds(entity, item_regex, enchantment) -> 
 (
 	if (entity~'gamemode_id'==3, return(0));

--- a/programs/survival/inventory_refill.sc
+++ b/programs/survival/inventory_refill.sc
@@ -1,3 +1,10 @@
+// stay loaded
+__config() -> (
+   m(
+      l('stay_loaded','true')
+   )
+);
+
 __on_player_right_clicks_block(player, item_tuple, hand, block, face, hitvec) ->
 (
 	start_pos = pos(block);

--- a/programs/survival/magic_doors.sc
+++ b/programs/survival/magic_doors.sc
@@ -1,6 +1,13 @@
 // when player right clicks with an empty hand on stained glass blob of blocks
 // they disappear for a moment and reappear soon
 
+// stay loaded
+__config() -> (
+   m(
+      l('stay_loaded','true')
+   )
+);
+
 __on_player_right_clicks_block(player, item_tuple, hand, block, face, hitvec) ->
 (
 	if (hand != 'mainhand', return());

--- a/programs/survival/prospectors_pick.sc
+++ b/programs/survival/prospectors_pick.sc
@@ -1,4 +1,11 @@
 // scarpet 1.4
+
+// stay loaded
+__config() -> (
+   m(
+      l('stay_loaded','true')
+   )
+);
  
 __holds(entity, item_regex, enchantment) -> 
 (

--- a/programs/survival/replace_inventory.sc
+++ b/programs/survival/replace_inventory.sc
@@ -1,3 +1,10 @@
+// stay loaded
+__config() -> (
+   m(
+      l('stay_loaded','true')
+   )
+);
+
 __on_player_uses_item(player, item_tuple, hand) -> if (hand == 'mainhand', _check_hand(player));
 __on_player_right_clicks_block(player, item_tuple, hand, block, face, hitvec) -> 
 	if (hand == 'mainhand' && item_tuple, _check_hand(player));

--- a/programs/survival/revive_coral.sc
+++ b/programs/survival/revive_coral.sc
@@ -1,6 +1,13 @@
 //allows player to revive dead corals with water bottles
 //By Ghoulboy
 
+// stay loaded
+__config() -> (
+   m(
+      l('stay_loaded','true')
+   )
+);
+
 __on_player_right_clicks_block (player, item_tuple,hand, block,face,hitvec) -> (
     // player holds a water bottle and targets a dead coral block
     if(item_tuple:0=='potion'&& block ~ '^dead_\\w+_coral_block$' && item_tuple:2:'Potion' == 'minecraft:water',

--- a/programs/survival/shear_corals.sc
+++ b/programs/survival/shear_corals.sc
@@ -1,6 +1,13 @@
 //Allows player to shear coral block of any type (even dead) to get between 0-5 fans or corals
 //By Ghoulboy
 
+// stay loaded
+__config() -> (
+   m(
+      l('stay_loaded','true')
+   )
+);
+
 __on_player_breaks_block(player, block) ->(
 	coraltype=block-'_coral_block';//Could do block ~'_coral_block', but I use var later to give player a new coral
 	if(coraltype!=block&&player~'holds':0=='shears'&&!player~'gamemode_id'%2,

--- a/programs/survival/shulkerboxes.sc
+++ b/programs/survival/shulkerboxes.sc
@@ -3,6 +3,13 @@
 // by gnembon
 ///
 
+// stay loaded
+__config() -> (
+   m(
+      l('stay_loaded','true')
+   )
+);
+
 __command() -> '
 Any shulkerbox with \'vacuum\' in its name
 will have vacuum capability

--- a/programs/survival/smasher.sc
+++ b/programs/survival/smasher.sc
@@ -1,4 +1,12 @@
 //scarpet v1.5
+
+// stay loaded
+__config() -> (
+   m(
+      l('stay_loaded','true')
+   )
+);
+
 __holds(entity, item_regex, enchantment) -> 
 (
 	if (entity~'gamemode_id'==3, return(0));

--- a/programs/survival/sneak_grow_overpowered.sc
+++ b/programs/survival/sneak_grow_overpowered.sc
@@ -1,3 +1,10 @@
+// stay loaded
+__config() -> (
+   m(
+      l('stay_loaded','true')
+   )
+);
+
 __on_tick() -> _sneak_grow();
 __on_tick_nether() -> _sneak_grow();
 __on_tick_ender() -> _sneak_grow();

--- a/programs/survival/speed.sc
+++ b/programs/survival/speed.sc
@@ -1,6 +1,13 @@
 //Speed display
 //By: Ghoulboy
 
+// stay loaded
+__config() -> (
+   m(
+      l('stay_loaded','true')
+   )
+);
+
 import('math','_euclidean');
 
 //Funcs

--- a/programs/survival/veinminer.sc
+++ b/programs/survival/veinminer.sc
@@ -1,3 +1,10 @@
+// stay loaded
+__config() -> (
+   m(
+      l('stay_loaded','true')
+   )
+);
+
 __holds(entity, item_regex, enchantment) -> 
 (
 	if (entity~'gamemode_id'==3, return(0));

--- a/programs/survival/very_basic_overworld_wither_cage_finder.sc
+++ b/programs/survival/very_basic_overworld_wither_cage_finder.sc
@@ -1,3 +1,10 @@
+// stay loaded
+__config() -> (
+   m(
+      l('stay_loaded','true')
+   )
+);
+
 find_cage(center_x, center_y, center_z, radius) -> 
 (
     locations = l();

--- a/programs/survival/villager_poi.sc
+++ b/programs/survival/villager_poi.sc
@@ -1,3 +1,10 @@
+// stay loaded
+__config() -> (
+   m(
+      l('stay_loaded','true')
+   )
+);
+
 //to keep track of last seen entity id per player
 global_last_entity_id = m();
 

--- a/programs/survival/vortex_effect.sc
+++ b/programs/survival/vortex_effect.sc
@@ -3,6 +3,14 @@
 //   [{lvl:3s,id:"minecraft:fortune"},{lvl:1s,id:"minecraft:unbreaking"}],Damage:0}}]
 // call with \'_axe\' to match any pickaxe
 // Handy function to check enchantment level on a tool
+
+// stay loaded
+__config() -> (
+   m(
+      l('stay_loaded','true')
+   )
+);
+
 __check_held_enchantment_level(entity, item_regex, enchantment) -> 
 (
 	if (entity~'gamemode_id'==3, return(0));

--- a/programs/survival/world_map.sc
+++ b/programs/survival/world_map.sc
@@ -9,7 +9,13 @@ use:
  - /world_map tp
 ';
 
-__config() -> { 'scope' -> 'global', 'stay_loaded' -> true };
+__config() -> 
+(
+	m(
+		l('stay_loaded', true),
+		l('scope', 'global')
+	)
+);
 
 global_map_view_distance = 0;
 


### PR DESCRIPTION
Since survival programs and meant to be used in normal gameplay, they should stay loaded on server/world restart. Therefore I added __config -> (m(l('stay_loaded','true')); to all the programs, keeping scope where implemented.