### PR TITLE
Shulkerboxes: Add ability to keep one item of each stack when restocking/swapping

### DIFF
--- a/programs/survival/shulkerboxes.sc
+++ b/programs/survival/shulkerboxes.sc
@@ -1,6 +1,7 @@
 ///
 // vacuum and restock
 // by gnembon
+// (keep ability added by Senth)
 ///
 
 __command() -> '
@@ -12,7 +13,8 @@ Current vacuum mode:'+global_vacuum+'
 use /shulkerboxes toggle_vacuum to change it
    
 Any shulkerbox with \'swap\' or \'restock\'
-followed with \'same\', \'first\', \'next\' or \'random\'
+followed with \'keep\', \'same\', \'first\',
+\'next\' or \'random\'
 will restock player inventory
  - swap: will swap a hotbar stack every time it changes
  - restock: will replace fully used up stacks
@@ -277,7 +279,7 @@ __swap_stack(player, slot, previous_item, item, count, tag) ->
          if ( shulker_item ~ 'shulker_box$' 
                && scount == 1 
                && (nametag = shulker_tag:'display.Name') != null
-               && (shulker_type = lower(parse_nbt(nametag):'text') ~ '(restock|swap)\\s+(same|next|random|first)')
+               && (shulker_type = lower(parse_nbt(nametag):'text') ~ '(restock|swap)\\s+(same|keep|next|random|first)')
                && ([action_type, idx_choice] = shulker_type; (action_type!='restock' || count == 0 ) )
                && (shulker_stacks = shulker_tag:'BlockEntityTag.Items[]') != null ,
             if (type(shulker_stacks)=='nbt', shulker_stacks = [shulker_stacks]);
@@ -285,7 +287,7 @@ __swap_stack(player, slot, previous_item, item, count, tag) ->
             for( shulker_stacks,
                if( _:'id' == item_fqdn,
                   replacement_index = if (
-                     idx_choice == 'same',
+                     idx_choice == 'same' || idx_choice == 'keep',
                         _i,
                      idx_choice == 'random', 
                         floor(rand(sb_item_count)),
@@ -310,6 +312,10 @@ __swap_stack(player, slot, previous_item, item, count, tag) ->
                   swapped_id = swapped_item_tag:'id';
                   swapped_count = swapped_item_tag:'Count';
                   swapped_tag = swapped_item_tag:'tag';
+                  // keep - skip if the stack size is 1
+                  if (idx_choice == 'keep' && swapped_count == 1,
+                     continue();
+                  );
                   // shulker box changes
                   if (count>0, // replace tag
                      // because 'minecraft:stone' gets parsed as a string 'minecraft' as a tag
@@ -318,7 +324,12 @@ __swap_stack(player, slot, previous_item, item, count, tag) ->
                      swapped_item_tag:'Count' = count+'b';
                      if (tag, swapped_item_tag:'tag' = tag, delete(swapped_item_tag:'tag'));
                      put(shulker_tag, 'BlockEntityTag.Items['+replacement_index+']', swapped_item_tag, 'replace');
-                  , // remove that item from the list
+                  , // else if, keep 1 in the shulker box
+                  idx_choice == 'keep',
+                     swapped_count += -1;
+                     swapped_item_tag:'Count' = 1+'b';
+                     put(shulker_tag, 'BlockEntityTag.Items['+replacement_index+']', swapped_item_tag, 'replace');
+                  , // else remove that item from the list
                      delete(shulker_tag, 'BlockEntityTag.Items['+replacement_index+']');
                   );
                   inventory_set(inventory, islot, 1, shulker_item, shulker_tag);


### PR DESCRIPTION
Hi,
I added another feature to shulkerboxes that I found myself wanting to have. I thought I could share it since it only adds features and doesn't change any original behavior. Feel free to reject it if you want to keep the functionality simple 🙂

**The problem**
After playing around with shulkerboxes.sc on my server I had one problem. Before I installed the app I always kept one item in the shulkerbox when taking out items. This makes it easier to shift-click in items again but also refill it either manually or automatically. I also know what has been in the shulkerbox (for example my different redstone boxes) so I can't forget one component when refilling.

**Solution**
I added the ability to write `restock keep` or `swap keep` which has the same functionality as `same` but always makes sure one item of the stack is left in the shulkerbox.

**Other behaviors**
Shulkerboxes that use the `keep` keyword together with `vacuum` are now easily resupplied. If you disable the restock ability when throwing items on the ground, you can even put back everything into the shulker boxes if you throw everything on the ground.

**Tested**
Have tested and tried it with both `restock keep` and `swap keep`, and also together with `vacuum`. But no extensive testing more than playing a few hours with this feature turned on.

**Keyword**
Is the keyword `keep` good enough? I wanted to keep it short especially since it's now useful together with vacuum, but another option would be `keep1` or `keepone`. Or there might be a better word to use.

(Thanks for implementing this feature and scarpet in the first place. It makes modding and creating useful features a lot easier)