### PR TITLE
Add survival/nopickup.sc

### DIFF
--- a/programs/survival/README.md
+++ b/programs/survival/README.md
@@ -86,10 +86,20 @@ Various scripts that modify various game elements, often replicating popular mod
 	
 ### nether_poi.sc:
 #### By Firigion
-	When holding an ender eye, all nether portal points of interest will be shown iwth a marker.
+	When holding an ender eye, all nether portal points of interest will be shown with a marker.
 	Useful when slicing portals, update supressing and debugging stuff.
 	Run /nether_poi to toggle on or off for each player. Refresh rate and radius are customizable.
 	
+### nopickup.sc:
+#### By KonaeAkira
+	Prevents picking up unwanted items (configurable) like rotten flesh from the ground to save inventory space.
+	/nopickup add <item> will add <item> to the blacklist
+	/nopickup remove <item> will remove <item> from the blacklist
+	/nopickup list will list all blacklisted items for current player
+	/nopickup clear will clear the blacklist, allowing the current player to pick up all items normally
+	Blacklists are player-bound and are saved even between server restarts
+	Requires carpet fabric-carpet-1.16.4-1.4.16+v201105 or above
+
 ### prospectors_pick.sc:
 #### By gnembonmc
 	There is a video on his channel about this.
@@ -238,4 +248,5 @@ Various scripts that modify various game elements, often replicating popular mod
 	Mdaff386
 	BisUmTo
 	TheCatSaber
+	KonaeAkira
 	(Many more hopefully!)

--- a/programs/survival/README.md
+++ b/programs/survival/README.md
@@ -94,6 +94,7 @@ Various scripts that modify various game elements, often replicating popular mod
 #### By KonaeAkira
 	Prevents picking up unwanted items (configurable) like rotten flesh from the ground to save inventory space.
 	/nopickup add <item> will add <item> to the blacklist
+	/nopickup setlimit <item> <count> sets the maximum allowed number of <item>s in inventory.
 	/nopickup remove <item> will remove <item> from the blacklist
 	/nopickup list will list all blacklisted items for current player
 	/nopickup clear will clear the blacklist, allowing the current player to pick up all items normally

--- a/programs/survival/nopickup.sc
+++ b/programs/survival/nopickup.sc
@@ -58,7 +58,7 @@ _count_in_inventory(item) -> (
 	while ((slot = inventory_find(player(), item:0, slot + 1)) != null, num_slots,
 		count += inventory_get(player(), slot):1;
 	);
-	return(count);
+	count;
 );
 
 // saves global_forbidden to the UUID's own config file
@@ -79,7 +79,6 @@ list() -> (
 	,
 		print('There are no forbidden items');
 	);
-	return(null);
 );
 
 add(item) -> (
@@ -91,7 +90,6 @@ add(item) -> (
 		_save_to_file();
 		print('You can no longer pick up [' + item:0 + ']');
 	);
-	return(null);
 );
 
 // sets the pickup limit for an item in the blacklist
@@ -115,7 +113,6 @@ remove(item) -> (
 	,
 		print('[' + item:0 + '] is not forbidden');
 	);
-	return(null);
 );
 
 clear() -> (
@@ -123,5 +120,4 @@ clear() -> (
 	global_forbidden = {};
 	_save_to_file();
 	print('Cleared the list of forbidden items');
-	return(null);
 );

--- a/programs/survival/nopickup.sc
+++ b/programs/survival/nopickup.sc
@@ -21,28 +21,36 @@ __config() -> {
 __command() -> null;
 
 global_uuid = null;
-global_forbidden = {};
+global_forbidden = {}; // item_name -> pickup_limit
 
 __on_player_connects(player) -> (
-	global_uuid = player~'uuid';
-	global_forbidden = parse_nbt(read_file(global_uuid, 'nbt'));
-	if (global_forbidden == 'null',
-		global_forbidden = {};
-	);
+	_init();
 );
 
 __on_player_collides_with_entity(player, entity) -> (
-	if (entity~'pickup_delay' == 0,
+	if (entity~'pickup_delay' == 0, // entity is an item and is ready to be picked up
 		item = entity~'item';
 		if (has(global_forbidden, item:0),
 			pickup_limit = global_forbidden:(item:0);
+			// check for pickup_limit = 0 seperately for performance reasons
+			// avoids counting items in the player's inventory most of the time
 			if (pickup_limit == 0 || _count_in_inventory(item) + item:1 > pickup_limit,
+				// prevent pick up by increasing the pickup delay
 				modify(entity, 'pickup_delay', 20);
 			);
 		);
 	);
 );
 
+_init() -> (
+	global_uuid = player~'uuid';
+	global_forbidden = parse_nbt(read_file(global_uuid, 'nbt'));
+	if (global_forbidden == 'null', // config file for this UUID doesn't exist
+		global_forbidden = {};
+	);
+);
+
+// returns how many of "item" is in the player's inventory
 _count_in_inventory(item) -> (
 	num_slots = inventory_size(player());
 	slot = -1;
@@ -53,16 +61,21 @@ _count_in_inventory(item) -> (
 	return(count);
 );
 
+// saves global_forbidden to the UUID's own config file
 _save_to_file() -> (
-	if (global_uuid == null, global_uuid = player~'uuid');
 	delete_file(global_uuid, 'nbt');
-	write_file(global_uuid, 'nbt', encode_nbt(global_forbidden, true));
+	if (global_forbidden != {}, // avoid converting an empty map to NBT
+		write_file(global_uuid, 'nbt', encode_nbt(global_forbidden));
+	);
 );
 
 list() -> (
+	if (global_uuid == null, _init()); // needed in case script is reloaded when players are connected
 	if (global_forbidden != {},
 		print('List of forbidden items:');
-		print(keys(global_forbidden));
+		for (pairs(global_forbidden),
+			print('	[' + _:0 + ', ' + _:1 + ']');
+		);
 	,
 		print('There are no forbidden items');
 	);
@@ -70,6 +83,7 @@ list() -> (
 );
 
 add(item) -> (
+	if (global_uuid == null, _init()); // needed in case script is reloaded when players are connected
 	if (has(global_forbidden, str(item:0)),
 		print('[' + item:0 + '] is already forbidden');
 	,
@@ -80,7 +94,9 @@ add(item) -> (
 	return(null);
 );
 
+// sets the pickup limit for an item in the blacklist
 setlimit(item, count) -> (
+	if (global_uuid == null, _init()); // needed in case script is reloaded when players are connected
 	if (has(global_forbidden, str(item:0)),
 		global_forbidden:(str(item:0)) = number(count);
 		_save_to_file();
@@ -91,6 +107,7 @@ setlimit(item, count) -> (
 );
 
 remove(item) -> (
+	if (global_uuid == null, _init()); // needed in case script is reloaded when players are connected
 	if (has(global_forbidden, str(item:0)),
 		delete(global_forbidden, str(item:0));
 		_save_to_file();
@@ -102,7 +119,9 @@ remove(item) -> (
 );
 
 clear() -> (
+	if (global_uuid == null, _init()); // needed in case script is reloaded when players are connected
 	global_forbidden = {};
+	_save_to_file();
 	print('Cleared the list of forbidden items');
 	return(null);
 );

--- a/programs/survival/nopickup.sc
+++ b/programs/survival/nopickup.sc
@@ -1,0 +1,80 @@
+// prevents unwanted items from filling up player inventories by allowing the
+// player to disable picking up specific items from the ground
+
+// requires carpet fabric-carpet-1.16.4-1.4.16+v201105 or above
+// works on both singleplayer and multiplayer
+// init is triggered on player logon, so if anything doesn't work, try relogging
+
+// written by KonaeAkira
+
+__config() -> {
+	'stay_loaded' -> true,
+	'legacy_command_type_support' -> true
+};
+
+__command() -> null;
+
+global_uuid = null;
+global_forbidden = {};
+
+__on_player_connects(player) -> (
+	global_uuid = player~'uuid';
+	global_forbidden = parse_nbt(read_file(global_uuid, 'nbt'));
+	if (global_forbidden == 'null',
+		global_forbidden = {};
+	);
+);
+
+__on_player_collides_with_entity(player, entity) -> (
+	if (entity~'pickup_delay' == 0,
+		if (has(global_forbidden, entity~'item':0),
+			modify(entity, 'pickup_delay', 20);
+		);
+	);
+);
+
+_save_to_file() -> (
+	if (global_uuid == null, global_uuid = player~'uuid');
+	delete_file(global_uuid, 'nbt');
+	write_file(global_uuid, 'nbt', encode_nbt(global_forbidden, true));
+);
+
+list() -> (
+	// print(global_forbidden);
+	if (global_forbidden != {},
+		print('List of forbidden items:');
+		print(keys(global_forbidden));
+	,
+		print('There are no forbidden items');
+	);
+	return(null);
+);
+
+add(item) -> (
+	if (has(global_forbidden, str(item:0)),
+		print('[' + item:0 + '] is already forbidden');
+	,
+		put(global_forbidden, str(item:0), 0);
+		_save_to_file();
+		print('You can no longer pick up [' + item:0 + ']');
+	);
+	return(null);
+);
+
+remove(item) -> (
+	item_str = str(item:0);
+	if (has(global_forbidden, str(item:0)),
+		delete(global_forbidden, str(item:0));
+		_save_to_file();
+		print('You can now pick up [' + item:0 + ']');
+	,
+		print('[' + item:0 + '] is not forbidden');
+	);
+	return(null);
+);
+
+clear() -> (
+	global_forbidden = {};
+	print('Cleared the list of forbidden items');
+	return(null);
+);


### PR DESCRIPTION
App that allows players to blacklist items that they do not want to pick up from the ground. Prevents unwanted items like rotten flesh from taking up precious inventory space.