### PR TITLE
Fix vacuum duplication when not all items are inserted

### DIFF
--- a/programs/survival/shulkerboxes.sc
+++ b/programs/survival/shulkerboxes.sc
@@ -72,9 +72,7 @@ __on_player_collides_with_entity(player, entity) -> if (global_vacuum == 'collis
                entity_event(entity, 'on_tick', '__item_animation', max_age, player);
             ,
                actual_left = __add_item_to_vacuum_sboxes(player, item, count, tag, true);
-               if (actual_left != 0, exit()); // this never happens, we just mock added them. Magic
-               modify(entity, 'nbt_merge', '{Item:{Count:0b}}');
-               modify(entity, 'remove')
+               modify(entity, 'nbt_merge', '{Item:{Count:'+actual_left+'b}}');
             )
          );
       );


### PR DESCRIPTION
### Problem
When only partial of the picked up stack can be inserted into a shulkerbox, it duplicates part of the stack.

### Steps to reproduce
1. Name a shulkerbox `vacuum`
1. Place 1 cobblestone in the shulkerbox
1. Pickup the shulkerbox.
1. Throw 64 cobblestone on the ground.

### What happens
The vacuum shulkerbox now contains 64 cobblestone and you also have 64 cobblestone in your inventory.

### Expected behavior
The vacuum shulkerbox contains 64 cobblestone and you pickup 1 cobblestone.

### Details
- Minecraft 1.16.4
- fabric-api-0.25.4+1.16
- fabric-carpet-1.16.4-1.4.16+v201105

### Comments
I ran `print(actual_left);` just before the removed if. It was never 0. Maybe the magic hack stopped working?