### PR TITLE
signs_for_water_streams: fix a duplication bug when using signs fron offhand

### DIFF
--- a/programs/survival/signs_for_water_streams.sc
+++ b/programs/survival/signs_for_water_streams.sc
@@ -57,7 +57,7 @@ __on_player_right_clicks_block(player, item_tuple, hand, block, face, hitvec) ->
         set(offset_by_one, sign, 'facing', face); // place the sign
         // Use one from the hand, but only if not in creative
         if( !player~'gamemode_id'%2,
-          inventory_set(player,  player~'selected_slot', count-1)
+          inventory_set(player, if(hand=='mainhand', player~'selected_slot', 40), count-1)
         )
       )
     )


### PR DESCRIPTION
signs_for_water_streams: fix a duplication bug when using signs from offhand.

Item in mainhand would get duplicated when using a sign from offhand. 

Fix is to detect if using offhand, and update the item count for slot '40' instead of the mainhand.

Is there a way to do it without using '40' as a magic value?