### PR TITLE
witch_hut became swamp_hut sometime during 1.16.x

### DIFF
--- a/programs/survival/world_map.sc
+++ b/programs/survival/world_map.sc
@@ -805,6 +805,7 @@ global_structure_data =
 global_structure_data:'end_city' = global_structure_data:'endcity';
 global_structure_data:'jungle_temple' = global_structure_data:'jungle_pyramid';
 global_structure_data:'desert_temple' = global_structure_data:'desert_pyramid';
+global_structure_data:'swamp_hut' = global_structure_data:'witch_hut';
 
 
 // chunk states / statuses


### PR DESCRIPTION
By leaving the old line, it should still work in earlier versions.