### PR TITLE
Upgrade deprecated usages in storage drawers

### DIFF
--- a/programs/survival/storage_drawers.sc
+++ b/programs/survival/storage_drawers.sc
@@ -6,7 +6,7 @@ global_dims = l('overworld', 'the_nether', 'the_end');
 
 __config() ->  {
 	'scope' -> 'global'
-}
+};
 
 //displays all controller positions and detailed content of the closest storage
 __command() ->

--- a/programs/survival/storage_drawers.sc
+++ b/programs/survival/storage_drawers.sc
@@ -23,7 +23,7 @@ __command() ->
 	in_dimension( current_player,
 		loaded_controllers = sort_key(
 			filter(global_controllers:current_dimension(), loaded(_)), 
-			__euclidean_sq(_,player_pos)
+			_euclidean_sq(_,player_pos)
 		);
 		if (loaded_controllers,
 			closest_controller = loaded_controllers:0;

--- a/programs/survival/storage_drawers.sc
+++ b/programs/survival/storage_drawers.sc
@@ -1,19 +1,12 @@
+import('math', '_euclidean_sq');
+
 global_controllers = null;
 global_banned_blocks = m('hopper', 'dropper', 'dispenser');
 global_dims = l('overworld', 'the_nether', 'the_end');
 
-// must turn
-// /carpet setDefault scriptsAutoload true
-// for the scripts to start with the world automatically
-__config() -> 
-(
-	m(
-		l('stay_loaded', true),
-		l('scope', 'global')
-	)
-);
-
-__distance_sq(v1, v2) -> reduce(v1-v2,_*_+_a,0);
+__config() ->  {
+	'scope' -> 'global'
+}
 
 //displays all controller positions and detailed content of the closest storage
 __command() ->
@@ -30,7 +23,7 @@ __command() ->
 	in_dimension( current_player,
 		loaded_controllers = sort_key(
 			filter(global_controllers:current_dimension(), loaded(_)), 
-			__distance_sq(_,player_pos)
+			__euclidean_sq(_,player_pos)
 		);
 		if (loaded_controllers,
 			closest_controller = loaded_controllers:0;
@@ -132,8 +125,6 @@ __load_controllers(tag) ->
 	)
 );
 
-__on_start();
-
 __add_controller(dimension, position) ->
 (
 	if (!has(global_controllers:dimension), exit());
@@ -152,9 +143,11 @@ __remove_controller(dimension, position) ->
 	__store_controllers()
 );
 
-__on_tick() -> __tick_drawers();
-__on_tick_nether() -> __tick_drawers();
-__on_tick_ender() -> __tick_drawers();
+__on_tick() -> (
+	for(global_dims,
+		in_dimension(_, __tick_drawers());
+	);
+);
 
 __tick_drawers() ->
 (


### PR DESCRIPTION
Fixes #186.

- Removes usages of `__on_tick_nether` and `__on_tick_end` and changes them to the current `__on_tick(in_dimension('...',...))`
  - As a bonus, this should also now work for non-vanilla dimensions by just specifying them in the list
- Removes useless things from the `__config`
- Imports `distance_sq` from Carpet's `math` library instead of recreating it
- It seems it also adds the newline at the end. Didn't know it wasn't there, it's nice that it got added automatically
- Oh, and it also removes calling `__on_start()` since that is now done by Carpet (same way since it's global), else would be called twice

I didn't touch the command system since it's basically the root command. Also didn't upgrade anything else because just in case, since I'm not familiar with the app and I don't want to break it without the need to or create any unnecessary diff. These were the basics.

Note: I still haven't tested this. I'll probably do it Soon™.