### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/app-suggestion.md
+++ b/.github/ISSUE_TEMPLATE/app-suggestion.md
@@ -1,0 +1,20 @@
+---
+name: App suggestion
+about: Suggest an idea for the app store or extra functionality of an existing one
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Create a report about an app that isn't working correctly
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Use block '....'
+3. Click the tool item '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem. You should add the error stacktrace here if it is displayed.
+
+**Environment**
+ - Carpet version:
+ - Minecraft version:
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Scarpet language bug or feature request
+    url: https://github.com/gnembon/fabric-carpet/issues
+    about: "Please submit Scarpet bugs and feature requests to the main Carpet repo."

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,10 @@
+---
+name: Question
+about: Ask how to do something in Scarpet
+title: ''
+labels: question
+assignees: ''
+
+---
+
+


### PR DESCRIPTION
This PR adds two (technically three) issue templates, one for bug reports, basically using the default Github template a bit adapted, one for app suggestions, with the enhancement default from Github, and a blank one for questions. It also keeps the possibility to create blank issues, and a link to tell people to create issues about Scarpet language bugs and feature requests to the Carpet repo.

The issues also get automagically labelled to their respective labels.

You can test them in my fork: https://github.com/altrisi/scarpet/issues/new/choose

Please suggest changes if you don't like something about them or have something to improve. I just slightly changed the defaults.