### PR TITLE
Add some matrix and vector maths

### DIFF
--- a/programs/fundamentals/math.sc
+++ b/programs/fundamentals/math.sc
@@ -42,6 +42,35 @@ distance(vec1, vec2) -> sqrt(reduce(vec1 - vec2, _a + _*_, 0));
 
 dot(vec1, vec2) -> reduce(vec1 * vec2, _a + _, 0);
 
+norm(vec) -> sqrt(reduce(vec, _a + _*_, 0));
+
+normalize(vec) -> vec / sqrt(reduce(vec, _a + _*_, 0));
+
+cross(v, w) -> [v:1*w:2 - v:2*w:1, v:2*w:0 - v:0*w:2, v:0*w:1 - v:1*w:0];
+
+outer_prod(v, w) -> map(w, v*_);
+
+corss_matrix(vec) -> (
+	[x, y, z] = vec;
+	[[0, -z, y], [z, 0, -x], [-y, x, 0]]
+);
+
+// the following methods assume a square matrix indexed by row (i.e, mat:0 is the first row)
+mat_times_vec(matrix, vec) -> map(matrix * map(vec, vec), reduce(_, _a+_, 0));
+
+mat_times_mat(mat1, mat2) -> (
+	mat2 = transpose(mat2);
+	map(mat1,
+		i = _i;
+		map(mat2,
+			j = _i;
+			dot(mat1:i, mat2:j)
+		)
+	)
+);
+
+transpose(mat) -> map(mat, i = _i; map(_, mat:_i:i) );
+
 highest_common_factor(num1,num2) -> (
 	q=1;
 	while(q!=0,num1*num2,
@@ -61,3 +90,6 @@ highest_common_factor_list(list)-> reduce(list, highest_common_factor(_,_a),list
 
 // computes LCM for a list of numbers
 lowest_common_multiple_list(list)-> reduce(list, lowest_common_multiple(_,_a), list:0);
+
+// convert yaw, pitch as given by MC into a normalized vector
+direction(yaw, pitch) -> [-sin(yaw)*cos(pitch), -sin(pitch), cos(pitch)*cos(yaw)];


### PR DESCRIPTION
I added a few funcitons, not sure if all of them should stay, but this is why we have reviews.

Comments on functions:
* `norm`
* `normalize`
added because it's slightly better than doing `distance(vec, 0)` and `vec/distance(vec, 0)`, respectively.

* `cross`(_product)
* `outer`(_product)
could be renamed to *`_product`. I left like this to inkeep with current naming of dot prouct being `dot`.

* `cross_matrix`
could be removed (along with `outer`). I added them because they are needed (useful?) when doing rottion about an arbitrary axis in 3D, which is sometimes useful. I'd be totally okay with removing these.

* `mat_times_vec`
For 3D rotations about cartesian axes and some other geometric mumbo jumbo.

* `mat_times_mat`
* `transpose`
for completeness. I haven't had to use them so far in any app. Again, could be removed. `mat_times_mat` is not particulrly efficient either, but I couldn't find a neat vectorized way to do it like I did for `mat_times_vec`.

* `direction`
There has been a bunch of people doing the maths themselves and reinventing the wheel. Why not provide users with the function?
