### PR TITLE
Update Cam: Actionbar instead of chat, simplify and fix timeout

### DIFF
--- a/programs/survival/cam.sc
+++ b/programs/survival/cam.sc
@@ -10,8 +10,8 @@ global_survival_timeout = 3;
 // additional player checks are here. comment lines that you think are not needed
 __assert_player_can_cam_out(player) ->
 (
-   if(!query(player,'nbt','OnGround'), exit('You must be on firm ground.'));
-   if(query(player,'nbt','Air') < 300, exit('You must be in air, not suffocating nor in liquids.'));
+   if(!query(player, 'nbt', 'OnGround'), exit('You must be on firm ground.'));
+   if(query(player, 'nbt', 'Air') < 300, exit('You must be in air, not suffocating nor in liquids.'));
    if(player ~ 'is_burning', exit('You must not be on fire.'));
    null
 );
@@ -21,11 +21,9 @@ __assert_player_can_cam_out(player) ->
 
 
 
-__config() -> (
-   m(
-      l('stay_loaded','true')
-   )
-);
+__config() -> {
+    'stay_loaded' -> 'true'
+};
 
 __command() ->
 (
@@ -36,34 +34,33 @@ __command() ->
          __remove_camera_effects(p);
          __restore_player_params(p, config);
          __remove_player_config(p~'name');
+         display_title(p, 'actionbar', format('y Exited camera mode'));
       ,
          if (__survival_defaults(p), 
-            __remove_camera_effects(p)
+            __remove_camera_effects(p);
+            display_title(p, 'actionbar', format('y Exited camera mode'));
          );
       );
    , current_gamemode == 'survival' && !global_is_in_switching, // else if survival - switch to spectator
       __assert_player_can_cam_out(p);
-      if (global_survival_timeout > 0,
-         global_is_in_switching = true;
-         for(range(global_survival_timeout, 0, -1), 
-            schedule((global_survival_timeout+1-_)*20, _(outer(_)) -> print(format('v camera mode in '+_+'...')))
-         );
-         player_name = p~'name';
-         player_dim = p~'dimension';
-         schedule((global_survival_timeout+1)*20, _(outer(player_name), outer(player_dim) )-> (
-            global_is_in_switching = false;
-            p = player(player_name);
-            if (p && p~'dimension' == player_dim,
-               __store_player_takeoff_params(p);
-               __turn_to_camera_mode(p);
-            )
-         ));
-      ,
-         __store_player_takeoff_params(p);
-         __turn_to_camera_mode(p);
-      )
+      
+      global_is_in_switching = true;
+      for(range(1, global_survival_timeout+1), 
+         schedule((global_survival_timeout - _) * 20, _(outer(_),outer(p)) -> display_title(p, 'actionbar', format('y Entering camera mode in '+_+'...')))
+      );
+      player_name = p~'name';
+      player_dim = p~'dimension';
+      schedule((global_survival_timeout)*20, _(outer(player_name), outer(player_dim)) -> (
+         global_is_in_switching = false;
+         p = player(player_name);
+         if (p && p~'dimension' == player_dim,
+            __store_player_takeoff_params(p);
+            __turn_to_camera_mode(p);
+            display_title(p, 'actionbar', format('y Entered camera mode'));
+         )
+      ));
    );
-   ''
+   null
 );
 
 
@@ -82,9 +79,6 @@ __get_player_stored_takeoff_params(player_name) ->
    config:'effects' = l();
    effects_tags = player_tag:'Effects.[]';
    if (effects_tags,
-      // fixing vanilla list parser
-      if (type(effects_tags)!='list',effects_tags = l(effects_tags));
-      
       for(effects_tags, etag = _;
          effect = m();
          effect:'name' = etag:'Name';


### PR DESCRIPTION
This PR updates the cam app to change a few things:

- Simplify timeout code:
  Previously, there were two branches for the switch code: one if there was timeout, another one if there wasn't. This PR simplifies it by instead of scheduling to timeout+1sec, scheduling to timeout, so if it's 0 it will run instantly (0*20 = 0). This also brings the next upgrade:
- Fix timeout not showing directly on command output and being +1:
  Until now timeout messages were sent since one second after the command was ran, which not only could make users wonder if it didn't work, but also made the timeout effectively one extra second.
- Remove empty chat messages:
  At some point, quite long ago, it was changed that in command functions, if they return an empty string they would send it to chat. Previously Scarpet would consider that "don't send anything", but it was changed and produced empty lines, so I changed that return to null.
- Use actionbar for messages:
  Makes use of the new actionbar API instead of chat, since it's something you really only need on that moment. Also adds an "entered/exited camera mode" message to inform the user (and to clear the entering in 1 message).
  Color was changed because it was already not really visible IMO, and since actionbar is smaller, it was even less visible
- Newer syntax and removal of unneeded code:
  Changes the config to use the new map syntax and removes a single-item to list converter in a nbt list getter, since that was already fixed in a PR to Carpet not that long ago.

Please give feedback! I'm also not sure about the entered/exited messages, and I'm even less sure about the color.