### PR TITLE
Update lifetimes.sc

### DIFF
--- a/programs/utilities/lifetimes.sc
+++ b/programs/utilities/lifetimes.sc
@@ -59,7 +59,7 @@ _report(verbose)->(
         total_time+=entry:0;
 		total_mobs+=entry:1;
     );
-    print('Total average lifetime for all mobs is: '+round(total_time/total_mobs*5)/100+' seconds');
+    print('Total average lifetime over '+total_mobs+' mobs is: '+round(total_time/total_mobs*5)/100+' seconds');
 	null
 );
 

--- a/programs/utilities/lifetimes.sc
+++ b/programs/utilities/lifetimes.sc
@@ -50,7 +50,7 @@ _report(verbose)->(
     total_time=0;
 	total_mobs=0;
 	minutes = round((tick_time()-global_start_time)/12)/100; //2 d.p
-    print('Average lifetimes for mobs (in ticks) over '+minutes+' minutes:');
+    print('Average lifetimes for mobs (in seconds) over '+minutes+' minutes:');
 	map_to_iterate_over = if(verbose, global_lifetimes, global_lifetimes_categories);
     for(map_to_iterate_over,
 		entry = map_to_iterate_over:_;
@@ -59,7 +59,7 @@ _report(verbose)->(
         total_time+=entry:0;
 		total_mobs+=entry:1;
     );
-    print('Total average lifetime for all mobs is: '+round(total_time/total_mobs*100)/100+' seconds');
+    print('Total average lifetime for all mobs is: '+round(total_time/total_mobs*5)/100+' seconds');
 	null
 );
 

--- a/programs/utilities/lifetimes.sc
+++ b/programs/utilities/lifetimes.sc
@@ -1,126 +1,75 @@
-//An app to tell the lifetimes of mobs which die, useful for debugging a mobfarm etc.
-//Can also specify an area and see lifetimes of mobs which die in that area. (Thanks to this suggestion: https://discord.com/channels/211786369951989762/573613501164159016/857161350014173234)
 // by Ghoulboy78
 
-import('math', '_round');
-
-help()-> print(
-    'Available commands:\n'+
-    '  /lifetimes start : Will start recording lifetimes of all mobs\n'+
-    '  /lifetimes start <pos1> <pos2>: Will start recording lifetimes of all mobs within an area defined by  positions\n'+
-    '  /lifetimes report [verbose] : Prints out current average mob lifetimes, broken down by mob category.'+
-    ' With added "verbose" keyword prints average lifetime for each mob type individually.\n'+
-    '  /lifetimes stop : Will print final full (and verbose) report of all mob lifetimes'
+__command()->(
+    print(format(
+        'wi Available commands:\n',
+        'ti	/lifetimes start :','wi  Will start recording lifetimes of all mobs\n',
+        'ti	/lifetimes report :','wi  Prints out current lifetimes of mob categories\n',
+        'ti	/lifetimes report_verbose :','wi  Prints out current lifetimes of mob types\n',
+        'ti	/lifetimes stop :','wi  Will print final full report of all mob lifetimes'
+    ));
+	null
 );
 
-__config()->{
-    'stay_loaded'->true,
-    'commands'->{
-        ''->'help',
-        'start'->['start', null, null],
-        'start <pos1> <pos2>'->'start',
-        'stop'->'stop',
-        'report'->['report', false],
-        'report verbose'->['report', true],
-    },
-    'scope'->'global'
-};
+global_start_time = 0;
 
-global_start_time = 0; //Used to keep track of total measurement time.
+global_lifetimes = {};
 
-global_positions=[null, null];
+global_lifetimes_categories = {};
 
-global_mob_category_lifetimes={};//to keep track of lifetimes across mob groups for shorter report
-
-global_mob_lifetimes={};//To keep track of which mob types are actually there along with a pair of the total lifetime and the number of mobs, so I can calculate average quickly
-
-//todo think of a better name for this variable
-global_lifetime_counters={};//In here I keep track of the starting lifetime of all mobs, and when they die I remove their entry here and add it to global_mob_lifetimes
-
-
-_track(e)-> (
-    global_lifetime_counters:e = tick_time();
-    print('Tracking '+e);
-    entity_event(e, 'on_death', _(e, r)-> (
-        //Checking if we are measuring within a box, and if so whether entity is in said box
-        if(global_positions!=[null, null] && __in_volume(global_positions:0, global_positions:1, pos(e)),
-
-            if(!has(global_mob_lifetimes,(e~'type')), global_mob_lifetimes:(e~'type') = [0,0]);//initialising counter if it doesn't exist
-            if(!has(global_mob_category_lifetimes,(e~'category')), global_mob_category_lifetimes:(e~'category') = [0,0]);
-            
-            global_mob_lifetimes:(e~'type'):0 += 1;
-            global_mob_lifetimes:(e~'type'):1 += tick_time() - global_lifetime_counters:e;//mob's lifetime, i.e birth time - death time.
-            //Doing the same, but for mob category for shorter report
-            global_mob_category_lifetimes:(e~'category'):0 += 1;
-            global_mob_category_lifetimes:(e~'category'):1 += tick_time() - global_lifetime_counters:e;
-        );
-        delete(global_lifetime_counters, e)
-    ))
+_track(e, r)->(
+	entry = global_lifetimes:str(e);
+	if(entry==null,
+		global_lifetimes:str(e) = [e~'age', 1],
+		global_lifetimes:str(e) = entry + [e~'age', 1] //can't use += cos of bug
+	);
+	
+	category = e~'category';
+	entry = global_lifetimes_categories:str(category);
+	if(entry==null,
+		global_lifetimes_categories:str(category) = [e~'age', 1],
+		global_lifetimes_categories:str(category) = entry + [e~'age', 1] //can't use += cos of bug
+	)
 );
 
-//Commands
-
-start(pos1, pos2)-> (
-    _reset();//Getting rid of previous values, in case we hadn't already. In theory unnecessary, in practice a JIC measure
-
-    global_positions = [pos1, pos2];//Check for null values is done in entity 'on_death' event
-    global_start_time = tick_time();
-    entity_load_handler('living', '_track');
-    print('Began tracking lifetimes for all mobs');
+start()->(
+	global_start_time = tick_time();
+	entity_load_handler('!misc',_(e, new)->if(new, entity_event(e, 'on_death', '_track')));
+	print('Began tracking mob lifetimes');
+	null
 );
 
-stop()-> (
-    if(global_start_time==0, exit(print(format('r You are not currently tracking'))));//cant stop before starting
-    entity_load_handler('living', null);
-    print('Stopped tracking lifetimes, printing report...');
-    report(true);
-    _reset()
-);
+stop()->_reset();
 
-report(verbose)->(
-    if(global_start_time==0, exit(print(format('r Can only report while tracking lifetimes!'))));//can only report while tracking ofc
-    total_count=0;
-    total_lifetime=0;
-    ticks = tick_time()-global_start_time;
-    print(str('Average lifetimes for mobs (in ticks) over %s ticks (%s mins %s s)%s:', 
-        ticks, floor(ticks/1200), round(ticks/20) % 60),
-        if(global_positions!=[null, null], str(' between %s and %s', global_positions:0, global_positions:1), '')
+report()->_report(false);
+
+report_verbose()->_report(true);
+
+_report(verbose)->(
+	if(global_start_time==0, exit('Nothing to report'));
+    total_time=0;
+	total_mobs=0;
+	minutes = round((tick_time()-global_start_time)/12)/100; //2 d.p
+    print('Average lifetimes for mobs (in ticks) over '+minutes+' minutes:');
+	map_to_iterate_over = if(verbose, global_lifetimes, global_lifetimes_categories);
+    for(map_to_iterate_over,
+		entry = map_to_iterate_over:_;
+        mob_avg=round(entry:0/entry:1*5)/100; //2 d.p
+        print('    '+_+': '+mob_avg+' seconds');
+        total_time+=entry:0;
+		total_mobs+=entry:1;
     );
-    if(verbose,
-        for(global_mob_lifetimes,
-            count = global_mob_lifetimes:_:0;
-            total = global_mob_lifetimes:_:1;
-            print(format(
-                str('gi     %s: %s mobs, avg lifetime: %s t', _, count, _round(total/count, 0.01)),
-            ));
-            total_count+=count;
-            total_lifetime+=total
-        ),
-        //shorter report
-        for(global_mob_category_lifetimes,
-            count = global_mob_category_lifetimes:_:0;
-            total = global_mob_category_lifetimes:_:1;
-            print(format(
-                str('gi     %s: %s mobs, avg lifetime: %s t', _, count, _round(total/count, 0.01)),
-            ));
-            total_count+=count;
-            total_lifetime+=total
-        )
-    );
-    print('\nTotal average lifetime for all mobs is: '+ _round(total_lifetime/total_count, 0.001)+' ticks')
+    print('Total average lifetime for all mobs is: '+round(total_time/total_mobs*100)/100+' seconds');
+	null
 );
+
+//Other functions
 
 _reset()->(
-    global_start_time = 0;
-    global_mob_lifetimes = {};
-    global_lifetime_counters = {};
-    global_mob_category_lifetimes = {}
+    report_verbose();
+    print('Reset all values');
+    global_start_time=0;
+    global_lifetimes={};
+    global_lifetimes_categories={};
+    null
 )
-
-__in_volume(box_1,box_2,pos)->(//Checks if pos is in volume defined by box_1 and box_2, todo move to a utility library
-    [x,y,z]=pos;
-    [min_x, min_y, min_z]=map(box_1, max(_, box_2:_i));
-    [max_x, max_y, max_z]=map(box_1, min(_, box_2:_i));
-
-    min_x <= x && x <= max_x && min_y <= y && y <=max_y && min_z <= z && z <= max_z
-);

--- a/programs/utilities/lifetimes.sc
+++ b/programs/utilities/lifetimes.sc
@@ -82,7 +82,10 @@ report(verbose)->(
     total_count=0;
     total_lifetime=0;
     ticks = tick_time()-global_start_time;
-    print(str('Average lifetimes for mobs (in ticks) over %s ticks (%s mins %s s):', ticks, floor(ticks/1200), round(ticks/20) % 60));
+    print(str('Average lifetimes for mobs (in ticks) over %s ticks (%s mins %s s)%s:', 
+        ticks, floor(ticks/1200), round(ticks/20) % 60),
+        if(global_positions!=[null, null], str(' between %s and %s', global_positions:0, global_positions:1), '')
+    );
     if(verbose,
         for(global_mob_lifetimes,
             count = global_mob_lifetimes:_:0;

--- a/programs/utilities/lifetimes.sc
+++ b/programs/utilities/lifetimes.sc
@@ -1,74 +1,123 @@
+//An app to tell the lifetimes of mobs which die, useful for debugging a mobfarm etc.
+//Can also specify an area and see lifetimes of mobs which die in that area. (Thanks to this suggestion: https://discord.com/channels/211786369951989762/573613501164159016/857161350014173234)
 // by Ghoulboy78
 
-__command()->(
-    print(
-        'Available commands:\n'+
-        '/lifetimes start : Will start recording lifetimes of all mobs\n'+
-        '/lifetimes report : Prints out current lifetimes of mobs\n'+
-        '/lifetimes stop : Will print final full report of all mob lifetimes'
-    );
-    return('')
+import('math', '_round');
+
+help()-> print(
+    'Available commands:\n'+
+    '  /lifetimes start : Will start recording lifetimes of all mobs\n'+
+    '  /lifetimes start <pos1> <pos2>: Will start recording lifetimes of all mobs within an area defined by  positions\n'+
+    '  /lifetimes report [verbose] : Prints out current average mob lifetimes, broken down by mob category.'+
+    ' With added "verbose" keyword prints average lifetime for each mob type individually.\n'+
+    '  /lifetimes stop : Will print final full (and verbose) report of all mob lifetimes'
 );
 
-//Globals
+__config()->{
+    'stay_loaded'->true,
+    'commands'->{
+        ''->'help',
+        'start'->['start', null, null],
+        'start <pos1> <pos2>'->'start',
+        'stop'->'stop',
+        'report'->['report', false],
+        'report verbose'->['report', true],
+    },
+    'scope'->'global'
+};
 
-global_start=false;
+global_start_time = 0; //Used to keep track of total measurement time.
 
-global_ticks=0;
+global_positions=[null, null];
 
-global_minutes=0.0;//floating point number
+global_mob_category_lifetimes={};//to keep track of lifetimes across mob groups for shorter report
 
-global_mobs=m();//To keep track of which mob types are actually there
+global_mob_lifetimes={};//To keep track of which mob types are actually there along with a pair of the total lifetime and the number of mobs, so I can calculate average quickly
 
-global_lifetimes=m();//SO that I can measure multiple lifetimes at the same time, I have to have an entry for each mob which he puts into global_lifetimes when he dies
+//todo think of a better name for this variable
+global_lifetime_counters={};//In here I keep track of the starting lifetime of all mobs, and when they die I remove their entry here and add it to global_mob_lifetimes
 
-global_lifetimes_global=m();
 
+_track(e)-> (
+    global_lifetime_counters:e = tick_time();
+    print('Tracking '+e);
+    entity_event(e, 'on_death', _(e, r)-> (
+        //Checking if we are measuring within a box, and if so whether entity is in said box
+        if(global_positions!=[null, null] && __in_volume(global_positions:0, global_positions:1, pos(e)),
 
-//Events
-
-__on_tick()->(
-    if(!global_start,return());
-    global_ticks+=1;
-    global_minutes=round(global_ticks/12)/100;//it would be round(global_ticks/1200(mins)*100)/100, but I simplified
-    e=filter(entity_selector('@e'),query(_,'category')!='misc');
-    for(e,
-        if(!query(_,'has_tag','lifetime'),
-            modify(_,'tag','lifetime');
-            global_mobs:query(_,'type')+=1;
-            entity_event(_,'on_death',_(e,c)->put(global_lifetimes_global,query(e,'type'),get(global_lifetimes_global,query(e,'type'))+global_lifetimes:e));//tried to define func but nulpointerexception bs
+            if(!has(global_mob_lifetimes,(e~'type')), global_mob_lifetimes:(e~'type') = [0,0]);//initialising counter if it doesn't exist
+            if(!has(global_mob_category_lifetimes,(e~'category')), global_mob_category_lifetimes:(e~'category') = [0,0]);
+            
+            global_mob_lifetimes:(e~'type'):0 += 1;
+            global_mob_lifetimes:(e~'type'):1 += tick_time() - global_lifetime_counters:e;//mob's lifetime, i.e birth time - death time.
+            //Doing the same, but for mob category for shorter report
+            global_mob_category_lifetimes:(e~'category'):0 += 1;
+            global_mob_category_lifetimes:(e~'category'):1 += tick_time() - global_lifetime_counters:e;
         );
-        global_lifetimes:_+=1
-    )
+        delete(global_lifetime_counters, e)
+    ))
 );
 
 //Commands
 
-start()->global_start=true;
+start(pos1, pos2)-> (
+    _reset();//Getting rid of previous values, in case we hadn't already. In theory unnecessary, in practice a JIC measure
 
-stop()->_reset();
-
-report()->(
-    total_avg=0.0;
-    print('Average lifetimes for mobs (in ticks) over '+global_minutes+' minutes:');
-    for(global_mobs,
-        mob_avg=round(global_lifetimes_global:_/(global_mobs:_*6))/10
-        print('    '+_+': '+mob_avg+' seconds');
-        total_avg=(total_avg+mob_avg)/2
-    );
-    print('Total average lifetime for all mobs is: '+total_avg+' seconds')
+    global_positions = [pos1, pos2];//Check for null values is done in entity 'on_death' event
+    global_start_time = tick_time();
+    entity_load_handler('living', '_track');
+    print('Began tracking lifetimes for all mobs');
 );
 
-//Other functions
+stop()-> (
+    if(global_start_time==0, exit(print(format('r You are not currently tracking'))));//cant stop before starting
+    entity_load_handler('living', null);
+    print('Stopped tracking lifetimes, printing report...');
+    report(true);
+    _reset()
+);
+
+report(verbose)->(
+    if(global_start_time==0, exit(print(format('r Can only report while tracking lifetimes!'))));//can only report while tracking ofc
+    total_count=0;
+    total_lifetime=0;
+    ticks = tick_time()-global_start_time;
+    print(str('Average lifetimes for mobs (in ticks) over %s ticks (%s mins %s s):', ticks, floor(ticks/1200), round(ticks/20) % 60));
+    if(verbose,
+        for(global_mob_lifetimes,
+            count = global_mob_lifetimes:_:0;
+            total = global_mob_lifetimes:_:1;
+            print(format(
+                str('gi     %s: %s mobs, avg lifetime: %s t', _, count, _round(total/count, 0.01)),
+            ));
+            total_count+=count;
+            total_lifetime+=total
+        ),
+        //shorter report
+        for(global_mob_category_lifetimes,
+            count = global_mob_category_lifetimes:_:0;
+            total = global_mob_category_lifetimes:_:1;
+            print(format(
+                str('gi     %s: %s mobs, avg lifetime: %s t', _, count, _round(total/count, 0.01)),
+            ));
+            total_count+=count;
+            total_lifetime+=total
+        )
+    );
+    print('\nTotal average lifetime for all mobs is: '+ _round(total_lifetime/total_count, 0.001)+' ticks')
+);
 
 _reset()->(
-    report();
-    print('Reset all values, can now measure lifetimes again.');
-    global_start=false;
-    global_ticks=0;
-    global_minutes=0.0;
-    global_mobs=m();
-    global_lifetimes=m();
-    global_lifetimes_global=m();
-    return('')
+    global_start_time = 0;
+    global_mob_lifetimes = {};
+    global_lifetime_counters = {};
+    global_mob_category_lifetimes = {}
 )
+
+__in_volume(box_1,box_2,pos)->(//Checks if pos is in volume defined by box_1 and box_2, todo move to a utility library
+    [x,y,z]=pos;
+    [min_x, min_y, min_z]=map(box_1, max(_, box_2:_i));
+    [max_x, max_y, max_z]=map(box_1, min(_, box_2:_i));
+
+    min_x <= x && x <= max_x && min_y <= y && y <=max_y && min_z <= z && z <= max_z
+);


### PR DESCRIPTION
Thanks to Smugless for suggestion in Sci discord which pushed me to redo the whole thing gooderly

It can now also take in an area, and only report deaths of mobs within that area. I think I might probably add some more specific reporting (i.e it tells in the report from which area it sampled deaths, if at all), but otherwise it's good.

It also has an extra function at the bottom (`__in_volume`) which I cooked up a while back (along with a bunch of other utility functions which deal with blocks/positions). Would it therefore be worthwhile putting it into a separate library, like `world_manipulation.scl` or smth like that? This would include like the `block_counter` functionality (in a single function) and perhaps `coord_export`.