### PR TITLE
Adding hyperlinks to apps in the readmes

### DIFF
--- a/programs/survival/README.md
+++ b/programs/survival/README.md
@@ -3,12 +3,12 @@ Various scripts that modify various game elements, often replicating popular mod
 
 ## Survival scarpet apps in alphabetical order with creator:
 
-### angel_block.sc:
+### [angel_block.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/angel_block.sc):
 #### By "Pegasus Epsilon" <pegasus@pimpninjas.org>
 	Reimplementation of Angel Blocks from RandomThings mod in scarpet 1.4.
 	Angel Block allows players to place a block in the middle of the air or water without having to place any support blocks which is especially helpful when trying to build in mid air or water.
 
-### auto_lighter.sc
+### [auto_lighter.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/auto_lighter.sc):
 #### By gnembon
 	When the player right clicks with a torch looking into the air and not on a block, this will start to send
 	out torches and light up the caves in the 128 block sphere around the player. If the player is in
@@ -16,59 +16,59 @@ Various scripts that modify various game elements, often replicating popular mod
 
 	App is multiplayer compatible.
 
-### auto_pickup.sc:
+### [auto_pickup.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/auto_pickup.sc):
 #### By gnembon
 	There is a video on his channel about this.
 	When you break a block, the item gets tp-ed to player, and left on ground if the inventory is full.
 	Also works for inventory blocks, delaying the check until they are done to grab the items off the ground.
 
-### bridge.sc:
+### [bridge.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/bridge.sc):
 #### By Aplet123
 	When holding golden sword(configurable), sneaking and clicking on a block, the blocks in the offhand will be placed.
 	Also comes with useful funcs, __set_nbt_in_slot(player, slot, tag_name, tag_value)
 	and __get_nbt_value_in_slot(player, slot, tag_name)
 	which can be very useful anywhere.
 
-### cam.sc:
+### [cam.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/cam.sc):
 #### By Gnembon
     As /c /s used to be in the olden 1.15- days, just configurable, safe with anti-cheat mechanisms, saving player landing location in
     app nbt's for future use. The whole shabang.
 
-### carried_totem.sc
+### [carried_totem.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/carried_totem.sc):
 #### By KingOfTheClouds
 	A Totem of Undying anywhere in the inventory (except in shulker boxes etc.) can activate as if it were held.
 
-### destructive_lightning.sc:
+### [destructive_lightning.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/destructive_lightning.sc):
 #### By Mdaff386
     Once you start it any lightning that strikes, either natural, summoned or a channeling trident,
     a tnt and fireball will be summoned to create a small crater where the lightning strikes.
 
-### drop_heads.sc:
+### [drop_heads.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/drop_heads.sc):
 #### By RubberDuck55
 	When a player is killed there is a 33% chance of a head to be dropped
 
-### easier_renweable_sponge.sc:
+### [easier_renweable_sponge.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/easier_renweable_sponge.sc):
 #### By Ghoulboy
 	If you kill one of each type of fish(Pufferfish, tropical fish, salmon, cod)
 	you have a 1/50 chance of getting a wet sponge.
 	Can be used to make renewable sponge without the use of lightning RNG manipulation,
 	which in 1.14+ is impossible, hence the name easier_renweable_sponge.
 
-### eyeremover.sc
+### [eyeremover.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/eyeremover.sc):
 #### By rv3r
 	Shift right-click on a filled end portal frame to empty it and receive the eye of ender. Note that any
 	existing portal will break.
 
 	Only really useful in peaceful.
 
-### hammer.sc:
+### [hammer.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/hammer.sc):
 #### By gnembonmc
 	There is a video on his channel about this.
 	If you have a stone pick, right click on block to set the area of effect of the hammer(1x1,3x3,5x5).
 	Then you can break multiple blocks at the same time, honouring enchantments like fortune or silk touch.
 	Useful for hollowing out large areas.
 
-### holy_hand_grenades.sc:
+### [holy_hand_grenades.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/holy_hand_grenades.sc):
 #### By gnembonmc
 	There is a video on his channel about this.
 	Reference to Monty Python and the Holy Grail (R.I.P Terry Jones and Graham Chapman).
@@ -76,40 +76,44 @@ Various scripts that modify various game elements, often replicating popular mod
 	falling block entities.
 	The higher the power, the further back the blocks go.
 
-### horse_stats.sc:
+### [horse_stats.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/horse_stats.sc):
 #### By KingOfTheClouds
 	The command /horse_stats prints the health, speed and jump attributes of the horse/donkey/mule the player is looking at.
 
-### inventory_refill.sc:
+### [inventory_refill.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/inventory_refill.sc):
 #### By gnembonmc
 	There is a video on his channel about this.
 	Right clicking on an inventory and having partially empty slots in your inventory will refill them from the inventory.
 	Left clicking will send your items to any unfilled slots in the inventory.
 	(Please add a better descreption as right now it just sounds like a less laggy storage_drawers.sc)
 
-### locate_block.sc:
+### [lava_sponge.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/lava_sponge.sc):
+#### By _GieR
+    Make sponge work on lava like water.
+
+### [locate_block.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/locate_block.sc):
 #### By Ghoulboy
 	This will allow you to see how many blocks of a specific type there are in an area around a point.
 	locate will tell you first 100 blocks, as well as how many there are in total, and you can tp to them by clicking in chat.
 	hist will print a histogram like in gnembon's ancient debris video, but this will accept any block, and if there are less than 	40 blocks for that y level, it will print a nice looking histogram.
 
-### magic_doors.sc:
+### [magic_doors.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/magic_doors.sc):
 #### By gnembonmc
 	There is a video on his channel about this.
 	If you right click with an empty hand on a bunch of stained glass, it will disappear for a moment and then reappear.
 	It's an automated glass sliding door but instead of sliding, the door disappears and allows players to walk through for a short period, and then reappears.
 
-### milkable_sheeps.sc:
+### [milkable_sheeps.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/milkable_sheeps.sc):
 #### By Gnottero
 	Allows the player to milk sheeps using a bucket.
 
-### nether_poi.sc:
+### [nether_poi.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/nether_poi.sc):
 #### By Firigion
 	When holding an ender eye, all nether portal points of interest will be shown with a marker.
 	Useful when slicing portals, update supressing and debugging stuff.
 	Run /nether_poi to toggle on or off for each player. Refresh rate and radius are customizable.
 
-### nopickup.sc:
+### [nopickup.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/nopickup.sc):
 #### By KonaeAkira
 	Prevents picking up unwanted items (configurable) like rotten flesh from the ground to save inventory space.
 	/nopickup add <item> will add <item> to the blacklist
@@ -120,7 +124,7 @@ Various scripts that modify various game elements, often replicating popular mod
 	Blacklists are player-bound and are saved even between server restarts
 	Requires carpet fabric-carpet-1.16.4-1.4.16+v201105 or above
 
-### prospectors_pick.sc:
+### [prospectors_pick.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/prospectors_pick.sc):
 #### By gnembonmc
 	There is a video on his channel about this.
 	If you hold a gold pick with fortune, it do a number of things:
@@ -130,13 +134,13 @@ Various scripts that modify various game elements, often replicating popular mod
 	Fortune 1 shows only iron, coal and redstone.
 	Fortune 3 shows diamond, lapis,gold, redstone and emerald, not iron and coal
 
-### replace_hotbar.sc:
+### [replace_hotbar.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/replace_hotbar.sc):
 #### By gnembonmc
 	There is a video on his channel about this.
 	If you run out of an item for any reason, it will be refilled from the hotbar, then shulker boxes in the hotbar.
 	Useful for large scale building, or afk sand placing around a monument.
 
-### replace_inventory.sc:
+### [replace_inventory.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/replace_inventory.sc):
 #### By gnembonmc
 	There is a video on his channel about this.
 	Allows a players inventory slots to be refilled when they run out with same blocks/items. First from the other slots in the players inventory,
@@ -144,144 +148,139 @@ Various scripts that modify various game elements, often replicating popular mod
 	This makes it useful for large scale building, or afk sand placing around a monument.
 	I guess its just like a better version of replace_hotbar.sc
 
-### revive_coral.sc:
+### [revive_coral.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/revive_coral.sc):
 #### By Ghoulboy
 	You can right click on a dead coral block with a water bottle to revive it, consuming the water.
 	The coral will be reset to normal, meaning that it will die again if you don't mine it.
 	It's useful in liaison with /carpet renewableCorals rule, as it can be used to simplify a coral block farm.
 
-### rope_ladders.sc:
+### [rope_ladders.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/rope_ladders.sc):
 #### By BisUmTo
 	Right clicking on a ladder with an other one, will extend the existing one down.
 	https://youtu.be/Mgz6XEIcpgc
 
-### shear_corals.sc:
+### [shear_corals.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/shear_corals.sc):
 #### By Ghoulboy
 	You can shear a coral, dead or alive, and there will be 0-5 drops which can be either coral fans or corals.
 	This is not op, as if you don't have silk touch, you will have to do this underwater, and at that stage you will likely be doing this while fighting off drowned, crouching on a magma block.
 	In creative it will not drop anything, like for any block.
 
-### shulkerboxes.sc:
+### [shulkerboxes.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/shulkerboxes.sc):
 #### By gnembon
 	Shulkerboxes get vacuum and restock ability.
 	Vacuum shulkerboxes will automatically suck in items bypassing player main inventory
 	Restock/swap shulkerboxes will automatically cause player to restock/swap stacks from their hotbar with items from the shulkerboxes
 
-### signs_for_water_streams.sc:
+### [signs_for_water_streams.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/signs_for_water_streams.sc):
 #### By indoorjetpacks
 	Hold any bucket in your offhand while placing signs will place the sign without getting the 'Edit sign message' prompt.
 	Useful for placing water/lava flows if you make a lot of them. Looking at you, SciCraft server.
 
-### silk_blockstates.sc:
+### [silk_blockstates.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/silk_blockstates.sc):
 #### By BisUmTo
 	While sneaking, the silk_touch enchantment saves the Blockstates and the Blockdata of mined blocks.
 	It doesn't apply to containers and blacklisted blocks.
 
-### silk_budding_amethyst.sc:
+### [silk_budding_amethyst.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/silk_budding_amethyst.sc):
 #### By "Scott Gudeman" (DragonCcrafted87)
 	Conversion of silk_spawners.sc
 	Allows to silk touch mine budding_amethyst if holding a diamond or netherite pick with silk touch.
 
-### silk_spawners.sc:
+### [silk_spawners.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/silk_spawners.sc):
 #### By "Pegasus Epsilon" <pegasus@pimpninjas.org>
 	Reimplementation of Silk Spawners mod in scarpet 1.5.
 	Allows to silk touch mine spawners if holding a diamond or netherite pick with silk touch.
 	Keep entity that you are spawning when you place back down.
 	Useful to make a crazy n-tuple spider farm or something like that.
 
-### simply_harvest.sc:
+### [simply_harvest.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/simply_harvest.sc):
 #### By Gnottero
 	Allows the player to right-click on a crop to harvest it. The "Fortune" enchantment affects drops
 
-### sleep_ignore_fake_players.sc:
+### [sleep_ignore_fake_players.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/sleep_ignore_fake_players.sc):
 #### By Sanluli36li
 	Skip the night and no longer required fake players to sleep.
 	Different from `OnePlayerSleeping`, still all real player is required on the server to cause night to pass.
 
-### smasher.sc:
+### [smasher.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/smasher.sc):
 #### By gnembonmc
 	There is a video on his channel about this.
 	Allows to smash a cave-like hollow in the ground, with random bits jutting out.
 	Doesn't drop items, and breaks all blocks, so don't confuse with veinminer.
 
-### sneak_grow_overpowered.sc:
+### [sneak_grow_overpowered.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/sneak_grow_overpowered.sc):
 #### By gnembonmc
 	This random ticks plants in a 23*23*17 volume around the player.
 	Blocks near the player will be random ticked more often.
 
-### speed.sc:
+### [speed.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/speed.sc):
 #### By Ghoulboy
     This app calculates speed of a player.
     It will display a number in the scoreboard. Divide said number by 100 to get actual speed.
     Speed toggle in minihud is obviously much better.
 
-### storage_drawers.sc:
+### [storage_drawers.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/storage_drawers.sc):
 #### By gnembonmc
 	There is a video on his channel about this.
 	https://www.youtube.com/watch?v=g7Ku73ElDBs
 	Cos im too lazy to write all the shit down.
 
-### updater.sc
+### [updater.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/updater.sc):
 #### By Firigion
-	Once loaded, right clicking an obsrever or budded block with a pice of bamboo will trigger or update it.
+	Once loaded, right clicking an observer or budded block with a pice of bamboo will trigger or update it.
 	Useful to replace some lost functionality of flint and steal or fireball, without creating a fire block.
 
-### vacuum.sc
+### [vacuum.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/vacuum.sc):
 #### By rv3r
 	Puts inventory items into inventory shulker boxes as long as the item is already present.
 	Idea first shown by Xisumavoid https://youtu.be/FMu8T8KriQY
 
-### veinminer.sc:
+### [veinminer.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/veinminer.sc):
 #### By gnembonmc
 	There is a video on his channel about this.
 	The more the sharpness, the more the veinminer, and it doesn't consume hunger.
 	Requires player to be sneaking.
 	It's as simple as that.
 
-### very_basic_overworld_wither_cage_finder.sc:
+### [very_basic_overworld_wither_cage_finder.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/very_basic_overworld_wither_cage_finder.sc):
 #### By gnembonmc
 	There is a video on his channel about this.any trade
 	It will search in the given radius of blocks for a 3*3 of bedrock, and nothing else.
 	It's very basic, hence it's name.
 
-### villager_auto_trader.sc
+### [villager_auto_trader.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/villager_auto_trader.sc):
 #### By Ghoulboy
 	When enabled, zombie villagers which can pick up loot, will change any emeralds in their hand for their first villager trade.
 	This only works for trades which take only emeralds as a first item, and nothing for the second.
 	NB: Zombie villagers will still be hostile and can despawn, so proper care is stilll required.
 	Trades happen every 6 seconds, as with piglin bartering.
 
-### villager_poi.sc:
+### [villager_poi.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/villager_poi.sc):
 #### By gnembonmc
 	Keeps track of villager poi system?
 	(Please enter an explanation, as it quite unclear)
 
-### vines_instant_mine.sc:
+### [vines_instant_mine.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/vines_instant_mine.sc):
 #### By BisUmTo
-	Shears will instant-mine vines
+	Shears will instant-mine vines (this is vanilla in 1.17+)
 
-### vortex_effect.sc:
+### [vortex_effect.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/vortex_effect.sc):
 #### By gnembon
 	There is a video on his channel about this
 	If you hold an ax with Sharpness, stuff will start flying around you at faster and faster speeds
 	Vortex 1 is a useful magnet, and Vortex 3 is a crazy random tornado which no-one wants except for a prank or messing around
 	I suppose you could use it with TNT to send it smashing into things as a powerful and volatile weapon
 
-### waypoints.sc:
+### [waypoints.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/waypoints.sc):
 #### By Firigion and boyenn
 	Adds a server-side waypoints system, where any player can add and teleport to waypoints that any player
 	creates. Permissions to	teleport are highly customizable (see https://youtu.be/OF_hY1sTRYY). It also
 	features the ability to render a line in direction of a waypoint (see https://youtu.be/0N2qVahMD7s).
 
-### world_map.sc:
+### [world_map.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/world_map.sc):
 #### By gnembon
 	https://www.youtube.com/watch?v=TqgyvnjEAn4
 	Cos gnembon was too lazy to wait for amidst to update.
-
-### lava_sponge.sc:
-#### By _GieR
-    Make sponge work on lava like water.
-
 
 ### Current content creators:
 	gnembonmc(obviously)


### PR DESCRIPTION
I think having the name of the app in the list (in the readme) be a link to the actual app can make it easier to shop for apps, rather than scrolling trough the list and then back up to the files.