### PR TITLE
deprecated nether tick in nether_poi.sc

### DIFF
--- a/programs/survival/nether_poi.sc
+++ b/programs/survival/nether_poi.sc
@@ -69,12 +69,10 @@ __do_on_tick(dim) -> (
 );
 
 __on_tick() -> (
-	__do_on_tick('overworld');
+	in_dimension('overworld',__do_on_tick('overworld'));
+	in_dimension('nether',__do_on_tick('the_nether'));
 );
 
-__on_tick_nether() -> (
-	__do_on_tick('the_nether')
-);
 
 // turn on for players that connect for the first time
 __on_player_connects(player) -> (


### PR DESCRIPTION
replaces deprecated  '__on_tick_nether()' function call with the updated 'in_dimension()' call inside '__on_tick()'