### PR TITLE
Add Scarpet Edit Installer

### DIFF
--- a/programs/building/README.md
+++ b/programs/building/README.md
@@ -23,3 +23,12 @@ Lets you replace blocks in an area with other blocks, preserving their block pro
 #### By Firigion
 
 A set of tools to define simple shapes (spheres, discs, circles, lines and planes) in 3D space by setting three points in the world and fitting the shape to those. Also has a fun eraser tool to delete blobs of connected blocks. [Here](https://github.com/Firigion/scarpets#shapes) you can find more specifi information.
+
+### scarpet_edit_installer.sc
+#### Installer by altrisi
+
+An app to easily install or update Scarpet Edit and its translations. It's not intended to be downloaded manually, and won't work that way. Instead, run `/script download building/scarpet_edit_installer.sc` in order to download it and make it install Scarpet Edit for you.
+
+Scarpet Edit is "A helpful app for designing and building. It is inspired by many mods, like World-Edit, but is not directly affiliated with any of them.".
+
+Check the [Scarpet Edit repo](https://github.com/Ghoulboy78/Scarpet-Edit) for more information, including documentation and steps to contribute. You can also see a list of commands ingame by running the `/se help` command. The full list of contributors can be found [over there](https://github.com/Ghoulboy78/Scarpet-edit/graphs/contributors).

--- a/programs/building/scarpet_edit_installer.sc
+++ b/programs/building/scarpet_edit_installer.sc
@@ -1,0 +1,70 @@
+// Scarpet app to download the Scarpet Edit (https://github.com/Ghoulboy78/Scarpet-edit) and its translations.
+// This app is not intended to be downloaded manually, and will only work if downloaded using the "/script download building/scarpet_edit_installer.sc" command
+// to download it from the app store.
+
+printf(text) -> (
+    print(format(text));
+);
+
+checkText = 'Check the Scarpet Edit license at https://github.com/Ghoulboy78/Scarpet-edit/blob/master/licence.txt';
+global_langs = ['es_la', 'it_it'];
+
+if (length(list_files('', 'text')) == 0,
+    firstTime = true;
+);
+
+genResources() -> (
+    resources = [];
+    for (global_langs,
+        resources += {
+            //'source' -> 'https://github.com/Ghoulboy78/Scarpet-edit/releases/latest/download/' + _ + '.json' TODO Change on SE release
+            'source' -> 'https://raw.githubusercontent.com/Ghoulboy78/Scarpet-edit/master/se.data/langs/' + _ + '.json'
+        };
+    );
+    resources += {
+        'source' -> 'https://raw.githubusercontent.com/Ghoulboy78/Scarpet-edit/master/licence.txt'
+    };
+    resources
+);
+
+__config() ->
+{
+    'scope' -> 'global',
+    'stay_loaded' -> false, // Don't keep it running if autoloaded
+    'requires' -> {
+        'carpet' -> '>=1.4.42'
+    },
+    'libraries' -> [
+        {
+            'source' -> 'https://github.com/Ghoulboy78/Scarpet-edit/releases/latest/download/se.sc'
+        }
+    ],
+    'resources' -> genResources()
+};
+
+if (length(list_files('', 'text')) != 0 && firstTime,
+    printf('l Scarpet Edit installed successfully (unless otherwise noted)');
+, read_file('licence', 'text'):0 != checkText,
+    printf('l Scarpet Edit updated successfully (unless otherwise noted)');
+, //else
+    schedule(0, _() -> ( // So it is printed after the loaded message and not printed on autoload
+        printf('r Error when downloading Scarpet Edit!');
+        print(format('r The Scarpet Edit installer is supposed to be used by running the "/script download building/scarpet_edit_installer.sc" command (click), not by loading it manually!',
+            '?/script download building/scarpet_edit_installer.sc',
+            '^g Click to get the download command'
+        ));
+        printf('r If you wish to update Scarpet Edit, just run the download command again.');
+        printf('r You can safely remove the installer (and its .data folder) once Scarpet Edit has been successfully installed');
+    ));
+    exit();
+);
+
+// Give ourselves a hint for next executions
+delete_file('licence', 'text');
+write_file('licence', 'text', checkText);
+
+// Install languages
+for (global_langs,
+    signal_event('se_install_lang', null, [_, read_file(_, 'json')]);
+    delete_file(_, 'json');
+);


### PR DESCRIPTION
Adds an installer for [Scarpet Edit](https://github.com/Ghoulboy78/Scarpet-edit).

The installer works by declaring SE as a dependency and checking before and after whether the app was actually installed.

Depends on Ghoulboy78/Scarpet-edit#85 getting into a release with the language files in it.

Testing is difficult. Sorry. But it Works on my machine™.