### PR TITLE
Add portalorient script

### DIFF
--- a/programs/survival/README.md
+++ b/programs/survival/README.md
@@ -133,6 +133,14 @@ Various scripts that modify various game elements, often replicating popular mod
 	Blacklists are player-bound and are saved even between server restarts
 	Requires carpet fabric-carpet-1.16.4-1.4.16+v201105 or above
 
+### [portalorient.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/portalorient.sc):
+#### By rv3r
+	Reorients a player after going through a Nether portal. App settings are per-player and default to not affecting player.
+	/portalorient off   - does not change player orientation
+	/portalorient air   - makes player face toward side with more air blocks
+	/portalorient solid - makes player face toward side with fewer solid blocks
+	In the event that each side of the portal has a matching number of valid blocks, does not reorient player.
+
 ### [prospectors_pick.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/prospectors_pick.sc):
 #### By gnembonmc
 	There is a video on his channel about this.

--- a/programs/survival/portalorient.sc
+++ b/programs/survival/portalorient.sc
@@ -1,30 +1,31 @@
 __config() ->
 (
-	m(
-		l('scope','player'),
-		l('stay_loaded',true),
+	{
+		['scope','player'],
+		['stay_loaded',true],
 		
-		l('commands',
-			m(
-				l('<mode>','__change')
-			)
-		),
-		l('arguments',
-			m(
-				l('mode',
-					m(
-						l('type','term'),
-						l('options',
-							l('off','air','solid')
-						),
-						l('suggest',
-							l('off','air','solid')
-						)
-					)
-				)
-			)
-		)
-	)
+		['commands',
+			{
+				['<mode>','__change']
+			}
+		],
+
+		['arguments',
+			{
+				['mode',
+					{
+						['type','term'],
+						['options',
+							['off','air','solid']
+						],
+						['suggest',
+							['off','air','solid']
+						]
+					}
+				]
+			}
+		]
+	}
 );
 
 //setup the script's data if nothing is there already
@@ -64,14 +65,14 @@ __on_player_changes_dimension(player, from_pos, from_dimension, to_pos, to_dimen
 		);
 
 		//get the corners of the portal and construct an offset to scan each side
-		offset = l(0,0,0);
+		offset = [0,0,0];
 		offset:(2 - axis) = 1;
 		corners =  __corners(center,offset);
 
 		//scan each side of the portal for blocks based on the player's chosen mode
 		//	air -> face the side with more air blocks
 		//	solid -> face the side with less solid blocks
-		sidelist = l();
+		sidelist = l[];
 		loop(2,
 			sign = 2 * _ - 1;
 			sidelist += volume(corners:0 + sign * offset,corners:1 + sign * offset,
@@ -108,9 +109,9 @@ __on_player_changes_dimension(player, from_pos, from_dimension, to_pos, to_dimen
 //according to profile_expr(), it's about 2.5x faster
 __corners(center,offset) ->
 (
-	corners = l();
+	corners = [];
 	//use the vector normal to the portal plane to construct a vector along the portal plane 
-	corneroffset = l(1,1,1) - offset;
+	corneroffset = [1,1,1] - offset;
 	//we'll need to check along each direction of the diagonal to find both corners
 	loop(2,
 		//-1 for negative direction, +1 for positive direction
@@ -119,38 +120,38 @@ __corners(center,offset) ->
 		//do it in order to prevent need for sorting
 		pos = copy(center);
 		//don't construct lists with rect() because this is much faster and no sorting is needed
-		check = map(l(range(21)),block(_ * listdirection * corneroffset + pos));
+		check = map([range(21)],block(_ * listdirection * corneroffset + pos));
 
 		//first find the edges
 		edge = __lastportal(check,copy(corneroffset),listdirection);
 		//we know the edge, but what direction do we go in?
 		//we should check which direction was the problem
-		verticalbool = block(edge + listdirection * l(0,1,0)) != 'nether_portal';
-		horizontalbool = block(edge + listdirection * (corneroffset - l(0,1,0))) != 'nether_portal';
+		verticalbool = block(edge + listdirection * [0,1,0]) != 'nether_portal';
+		horizontalbool = block(edge + listdirection * (corneroffset - [0,1,0])) != 'nether_portal';
 		if(verticalbool && horizontalbool,
 			//no blocks left that are a nether portal
 			//stop
-			direction = l(0,0,0),
+			direction = [0,0,0],
 			verticalbool,
 			//block above or below is not a nether portal
 			//start checking horizontally
-			direction = corneroffset - l(0,1,0),
+			direction = corneroffset - [0,1,0],
 			horizontalbool,
 			//block to left or right is not a nether portal
 			//start checking vertically
-			direction = l(0,1,0)
+			direction = [0,1,0]
 		);
 
 		//then find the corners
 		pos = copy(edge);
-		edges = l();
+		edges = [];
 		//again, don't construct lists with rect() because this is much faster and no sorting is needed
 		//this function is 2x faster when this list is made loop() instead of rect()
-		if(direction != l(0,0,0),
+		if(direction != [0,0,0],
 			//length(check) - check ~ edge to prevent checking too many blocks
-			edges = map(l(range(length(check) - check ~ edge)),block(_ * listdirection * direction + pos)),
-		   	//if we're already at the corner after the first check, we only need one block
-			edges = l(block(pos));
+			edges = map([range(length(check) - check ~ edge)],block(_ * listdirection * direction + pos)),
+			//if we're already at the corner after the first check, we only need one block
+			edges = [block(pos)];
 		);
 
 		//find which blocks along the edges are actually the corners
@@ -177,7 +178,7 @@ __lastportal(blocklist,direction,sign) ->
 			//if we are travelling along a diagonal, we might be at the intersection of two corners
 			//in this case, we should check that the next block vertically or horizontally is a nether portal
 			//this is especially important if your resulting position was a corner of the portal
-			adjacent = block(pos(_) + (sign || 1) * direction) == 'nether_portal' || block(pos(_) + (sign || 1) * l(0,1,0)) == 'nether_portal';
+			adjacent = block(pos(_) + (sign || 1) * direction) == 'nether_portal' || block(pos(_) + (sign || 1) * [0,1,0]) == 'nether_portal';
 			//if we were moving sideways, we can ignore this aspect and just require the next block in the list
 			//	to be a nether portal
 			nextbool || (direction && !adjacent)

--- a/programs/survival/portalorient.sc
+++ b/programs/survival/portalorient.sc
@@ -1,27 +1,24 @@
 __config() ->
 (
-	return(
-		m(
-			l('scope','player'),
-			l('stay_loaded',true),
-			
-			l('commands',
-				m(
-					l('<mode>','__change')
-				)
-			),
-
-			l('arguments',
-				m(
-					l('mode',
-						m(
-							l('type','term'),
-							l('options',
-								l('off','air','solid')
-							),
-							l('suggest',
-								l('off','air','solid')
-							)
+	m(
+		l('scope','player'),
+		l('stay_loaded',true),
+		
+		l('commands',
+			m(
+				l('<mode>','__change')
+			)
+		),
+		l('arguments',
+			m(
+				l('mode',
+					m(
+						l('type','term'),
+						l('options',
+							l('off','air','solid')
+						),
+						l('suggest',
+							l('off','air','solid')
 						)
 					)
 				)
@@ -152,6 +149,7 @@ __corners(center,offset) ->
 		if(direction != l(0,0,0),
 			//length(check) - check ~ edge to prevent checking too many blocks
 			edges = map(l(range(length(check) - check ~ edge)),block(_ * listdirection * direction + pos)),
+		   	//if we're already at the corner after the first check, we only need one block
 			edges = l(block(pos));
 		);
 

--- a/programs/survival/portalorient.sc
+++ b/programs/survival/portalorient.sc
@@ -6,6 +6,7 @@ __config() ->
 		
 		['commands',
 			{
+				['','__guide'],
 				['<mode>','__change']
 			}
 		],
@@ -33,7 +34,22 @@ __config() ->
 __on_start() ->
 (
 	if(!load_app_data(),
-		store_app_data(m());
+		store_app_data({});
+	)
+);
+
+//prints script explanation when command is called with no arguments
+__guide() ->
+(
+	print(player(),
+		join('\n',
+			[
+				'Reorients player when travelling through a nether portal',
+				' /portalorient off   - does not change player orientation',
+				' /portalorient air   - face side with more air blocks',
+				' /portalorient solid - face side with fewer solid blocks'
+			]
+		)
 	)
 );
 

--- a/programs/survival/portalorient.sc
+++ b/programs/survival/portalorient.sc
@@ -1,0 +1,188 @@
+__config() ->
+(
+	return(
+		m(
+			l('scope','player'),
+			l('stay_loaded',true),
+			
+			l('commands',
+				m(
+					l('<mode>','__change')
+				)
+			),
+
+			l('arguments',
+				m(
+					l('mode',
+						m(
+							l('type','term'),
+							l('options',
+								l('off','air','solid')
+							),
+							l('suggest',
+								l('off','air','solid')
+							)
+						)
+					)
+				)
+			)
+		)
+	)
+);
+
+//setup the script's data if nothing is there already
+//it's an empty map, so players without data will have a null mode
+__on_start() ->
+(
+	if(!load_app_data(),
+		store_app_data(m());
+	)
+);
+
+//set a new value for the player's mode from the command
+__change(mode) ->
+(
+	data = load_app_data();
+	data:str(player()) = mode;
+	store_app_data(data);
+);
+
+//when a player goes through a portal, change their yaw if they don't have
+//	it turned off and travelled to or from the nether
+__on_player_changes_dimension(player, from_pos, from_dimension, to_pos, to_dimension) ->
+(
+	//get player and their current mode
+	p = player;
+	mode = load_app_data():str(p);
+
+	//only trigger under certain conditions
+	if(mode != 'off' && mode != null && (from_dimension == 'the_nether' || to_dimension == 'the_nether'),
+		//round the player's position
+		center = map(to_pos,floor(_));
+
+		//get the portal axis
+		if(block_state(block(center)):'axis' == 'x',
+			axis = 0,
+			axis = 2;
+		);
+
+		//get the corners of the portal and construct an offset to scan each side
+		offset = l(0,0,0);
+		offset:(2 - axis) = 1;
+		corners =  __corners(center,offset);
+
+		//scan each side of the portal for blocks based on the player's chosen mode
+		//	air -> face the side with more air blocks
+		//	solid -> face the side with less solid blocks
+		sidelist = l();
+		loop(2,
+			sign = 2 * _ - 1;
+			sidelist += volume(corners:0 + sign * offset,corners:1 + sign * offset,
+				if(mode == 'air',
+					air(_),
+					mode == 'solid',
+					1 - solid(_);
+				);
+			);
+		);
+
+		//compare the two sides to determine which direction the player should face
+		if(sidelist:0 > sidelist:1,
+			yaw = -45 * axis + 180,
+			sidelist:1 > sidelist:0,
+			yaw = -45 * axis,
+			//if the two sides had matching numbers of valid blocks, don't change anything
+			yaw = p ~ 'yaw'
+		);
+
+		//modify the player's head and body yaw
+		modify(p,'yaw',yaw);
+		modify(p,'body_yaw',yaw);
+	)
+);
+
+//tracks portal blocks along a diagonal until it encounters an edge,
+//	and then travels along the edge to find the corner
+//this is faster than using scan() on the portal(20 blocks up, down, left, and right) to
+//	find the corners because it checks less than 50 blocks instead of 1000+ blocks
+//according to profile_expr(), it's about 10x faster,
+//this is also faster than scanning a single row up, down, left, and right because using
+//	the diagonal checks two directions at once
+//according to profile_expr(), it's about 2.5x faster
+__corners(center,offset) ->
+(
+	corners = l();
+	//use the vector normal to the portal plane to construct a vector along the portal plane 
+	corneroffset = l(1,1,1) - offset;
+	//we'll need to check along each direction of the diagonal to find both corners
+	loop(2,
+		//-1 for negative direction, +1 for positive direction
+		listdirection = 2 * _ - 1;
+		//generate a list of blocks for checking later
+		//do it in order to prevent need for sorting
+		pos = copy(center);
+		//don't construct lists with rect() because this is much faster and no sorting is needed
+		check = map(l(range(21)),block(_ * listdirection * corneroffset + pos));
+
+		//first find the edges
+		edge = __lastportal(check,copy(corneroffset),listdirection);
+		//we know the edge, but what direction do we go in?
+		//we should check which direction was the problem
+		verticalbool = block(edge + listdirection * l(0,1,0)) != 'nether_portal';
+		horizontalbool = block(edge + listdirection * (corneroffset - l(0,1,0))) != 'nether_portal';
+		if(verticalbool && horizontalbool,
+			//no blocks left that are a nether portal
+			//stop
+			direction = l(0,0,0),
+			verticalbool,
+			//block above or below is not a nether portal
+			//start checking horizontally
+			direction = corneroffset - l(0,1,0),
+			horizontalbool,
+			//block to left or right is not a nether portal
+			//start checking vertically
+			direction = l(0,1,0)
+		);
+
+		//then find the corners
+		pos = copy(edge);
+		edges = l();
+		//again, don't construct lists with rect() because this is much faster and no sorting is needed
+		//this function is 2x faster when this list is made loop() instead of rect()
+		if(direction != l(0,0,0),
+			//length(check) - check ~ edge to prevent checking too many blocks
+			edges = map(l(range(length(check) - check ~ edge)),block(_ * listdirection * direction + pos)),
+			edges = l(block(pos));
+		);
+
+		//find which blocks along the edges are actually the corners
+		corners:_ = __lastportal(edges,null,null);
+	);
+	return(corners);
+);
+
+//find last portal block before non portal block from a list of blocks
+//also catches edge case of two intersecting portals
+__lastportal(blocklist,direction,sign) ->
+(
+	//can't check the next value if there's only one so just return what we were given
+	if(length(blocklist) == 1,
+		return(pos(blocklist:0));
+	);
+	//we won't care about the vertical component when using this
+	direction:1 = 0;
+	pos(
+		first(blocklist,
+			//if the next block in the list is not a nether portal, we're at the edge of the portal
+			//we could check for obsidian but this way the script doesn't mind if you removed it
+			nextbool = blocklist:(_i + 1) != 'nether_portal';
+			//if we are travelling along a diagonal, we might be at the intersection of two corners
+			//in this case, we should check that the next block vertically or horizontally is a nether portal
+			//this is especially important if your resulting position was a corner of the portal
+			adjacent = block(pos(_) + (sign || 1) * direction) == 'nether_portal' || block(pos(_) + (sign || 1) * l(0,1,0)) == 'nether_portal';
+			//if we were moving sideways, we can ignore this aspect and just require the next block in the list
+			//	to be a nether portal
+			nextbool || (direction && !adjacent)
+		);
+	)
+);

--- a/programs/survival/portalorient.sc
+++ b/programs/survival/portalorient.sc
@@ -86,16 +86,19 @@ __on_player_changes_dimension(player, from_pos, from_dimension, to_pos, to_dimen
 
 		//compare the two sides to determine which direction the player should face
 		if(sidelist:0 > sidelist:1,
-			yaw = -45 * axis + 180,
+			yaw = -45 * axis + 180;
+			body_yaw = yaw,
 			sidelist:1 > sidelist:0,
-			yaw = -45 * axis,
+			yaw = -45 * axis;
+			body_yaw = yaw,
 			//if the two sides had matching numbers of valid blocks, don't change anything
-			yaw = p ~ 'yaw'
+			yaw = p ~ 'yaw';
+			body_yaw = p ~ 'body_yaw'
 		);
 
 		//modify the player's head and body yaw
 		modify(p,'yaw',yaw);
-		modify(p,'body_yaw',yaw);
+		modify(p,'body_yaw',body_yaw);
 	)
 );
 

--- a/programs/survival/portalorient.sc
+++ b/programs/survival/portalorient.sc
@@ -156,7 +156,7 @@ __corners(center,offset) ->
 		//find which blocks along the edges are actually the corners
 		corners:_ = __lastportal(edges,null,null);
 	);
-	return(corners);
+	corners
 );
 
 //find last portal block before non portal block from a list of blocks


### PR DESCRIPTION
This is a simple utility I wrote to prevent headaches when travelling through Nether portals. Makes the player always face a cardinal direction that is "out" of the portal so you don't have to spin around if you forget which way you're supposed to face for each specific portal in your world. This is accomplished by checking each side of the portal for blocks and making the player face the corresponding side(more air blocks or fewer solid blocks) depending on their setting. In the event of a tie, no side is preferred and the player will simply face their original direction.