### PR TITLE
Fix extra newline sent after /cam command

### DIFF
--- a/programs/survival/cam.sc
+++ b/programs/survival/cam.sc
@@ -63,7 +63,7 @@ __command() ->
          __turn_to_camera_mode(p);
       )
    );
-   ''
+   null
 );
 
 


### PR DESCRIPTION
Fixes #250
Basically the return value for the `__command` function was `''`, which ended up sending a random blank line, so I changed it to `null`