### PR TITLE
A fix for `playerme` hotbar

### DIFF
--- a/programs/survival/playerme.sc
+++ b/programs/survival/playerme.sc
@@ -40,7 +40,7 @@ __config() -> {
     },
     'arguments' -> {
         'ticks' -> {'type' -> 'int', 'min' -> 1, 'max' -> 72000, 'suggest' -> [20]},
-        'hotbarslot' -> {'type' -> 'int', 'min' -> 0, 'max' -> 8, 'suggest' -> [1,2,3,4,5,6,7,8,9]},
+        'hotbarslot' -> {'type' -> 'int', 'min' -> 1, 'max' -> 9, 'suggest' -> [1,2,3,4,5,6,7,8,9]},
     }
 };
 


### PR DESCRIPTION
`playerme hotbar 0` no longer works with more recent versions of Carpet and `playerme hotbar 9` errors. The suggestions also hint at this mishap as well.

The integer range from the argument should instead range from 1 to 9 instead of 0 to 8.