### PR TITLE
Adding tag and block support to the filters

### DIFF
--- a/programs/utilities/block_counter.sc
+++ b/programs/utilities/block_counter.sc
@@ -1,9 +1,15 @@
+//Counts blocks in a given region, optionally filtering by block type or tag. 
+//Prints the output into a chat or a file.
+//By gnembom and Firigion
+
 __config() ->
 {
    'commands' -> {
       '<from_pos> <to_pos>' -> 'count_blocks',
       '<from_pos> <to_pos> <filter>' -> 'count_blocks_filter',
-   }
+      '<from_pos> <to_pos> <blockpredicate>' -> 'count_blocks_predicate',
+   },
+   'allow_command_conflicts' -> true
 };
 
 count_blocks(from_pos, to_pos) ->
@@ -18,6 +24,22 @@ count_blocks_filter(from_pos, to_pos, filtr) ->
     stats = {}; total = 0;
     volume(from_pos, to_pos, total += 1; if (_~filtr, stats:str(_) += 1 ) );
     tally(stats, total);
+);
+
+count_blocks_tag(from_pos, to_pos, tag) ->
+(
+    stats = {}; total = 0;
+    volume(from_pos, to_pos, total += 1; if (block_tags(_, tag), stats:str(_) += 1 ) );
+    tally(stats, total);
+);
+
+count_blocks_predicate(from_pos, to_pos, predicate) ->
+(
+    [block, tag, trash, trash] = predicate;
+    if(block==null, 
+      count_blocks_tag(from_pos, to_pos, tag),
+      count_blocks_filter(from_pos, to_pos, filtr)
+    )
 );
 
 tally(stats, grand_total) ->
@@ -47,3 +69,4 @@ dpad(num, wid) ->
    if (length(strn) < wid, strn = '...'*(wid-length(strn))+strn);
    strn;
 )
+


### PR DESCRIPTION
Adding a few more features ot `block_counter.sc` to make it more flexible and easy to use. I'll start the PR, but will prolly be adding to it as I go, since idk how many features I wanna implement. This is the list i got:

[*] tag filtering
[*] block name suggestions for filters
[] multiple blocks or filters (prolly not gonna do it)
[] print to file
[] save `y` value sof blocks to tally per  value isntead of total
[] automatic histograms once I add y values