### PR TITLE
Fix for case where force-gamemode is on

### DIFF
--- a/programs/survival/cam.sc
+++ b/programs/survival/cam.sc
@@ -164,3 +164,5 @@ __survival_defaults(player) ->
    print(format('rb Cannot find a safe spot to land within 32 blocks.'));
    false;
 );
+
+__on_player_connects(player) -> if( __get_player_stored_takeoff_params(player~'name'), modify(player, 'gamemode' , 'spectator' ));

--- a/programs/survival/cam.sc
+++ b/programs/survival/cam.sc
@@ -165,4 +165,7 @@ __survival_defaults(player) ->
    false;
 );
 
+// This fixes the case where the server has force-gamemode on, in which case the player would be put
+// into survival in the location they logged out in camera mode, bypassing the sign-off actions of the app.
+// __get_player_stored_takeoff_params evaluates true-y when player was in cam mode before logging out
 __on_player_connects(player) -> if( __get_player_stored_takeoff_params(player~'name'), modify(player, 'gamemode' , 'spectator' ));


### PR DESCRIPTION
When force-gamemode is on, the server puts a player that logged out in camera mode into survival mode when loggin in. this of course breaks things. A simple check should fix that.