### PR TITLE
Add experience bottling through enchanting table

### DIFF
--- a/programs/survival/README.md
+++ b/programs/survival/README.md
@@ -82,6 +82,11 @@ Various scripts that modify various game elements, often replicating popular mod
 	you have a 1/50 chance of getting a wet sponge.
 	Can be used to make renewable sponge without the use of lightning RNG manipulation,
 	which in 1.14+ is impossible, hence the name easier_renweable_sponge.
+	
+### [enchanting_table_bottling.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/enchanting_table_bottling.sc):
+#### By Firigion
+	Shift right clicking on an enchanting table with an empty glass bottle consumes it and generates a
+	bottle o' enchanting at the cost of a bit more xp that you would gain from using the bottle.
 
 ### [eyeremover.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/eyeremover.sc):
 #### By rv3r

--- a/programs/survival/enchanting_table_bottling.sc
+++ b/programs/survival/enchanting_table_bottling.sc
@@ -3,11 +3,11 @@ global_xp_cost = 8;
 __on_player_right_clicks_block(player, item, hand, block, f, h) -> (
 	if(
 		player~'gamemode_id'%2==0 && //survival or adventure mode
+		player~'sneaking' && //they didn't open the UI
 		item:0 == 'glass_bottle' &&
 		item:2 == null && //doesn't have nbt
 		block == 'enchanting_table' &&
-		player~'sneaking' && //they didn't open the UI
-		player~'xp' >= global_xp_cost, //they ahve enough xp
+		player~'xp' >= global_xp_cost, //they have enough xp
 
 		modify(player, 'add_xp', -global_xp_cost);
 		slot = if(hand=='mainhand', player~'selected_slot', -1);

--- a/programs/survival/enchanting_table_bottling.sc
+++ b/programs/survival/enchanting_table_bottling.sc
@@ -1,0 +1,18 @@
+global_xp_cost = 8;
+
+__on_player_right_clicks_block(player, item, hand, block, f, h) -> (
+	if(
+		player~'gamemode_id'%2==0 && //survival or adventure mode
+		item:0 == 'glass_bottle' &&
+		item:2 == null && //doesn't have nbt
+		block == 'enchanting_table' &&
+		player~'sneaking' && //they didn't open the UI
+		player~'xp' >= global_xp_cost, //they ahve enough xp
+
+		modify(player, 'add_xp', -global_xp_cost);
+		slot = if(hand=='mainhand', player~'selected_slot', -1);
+		inventory_set(player, slot, item:1 - 1);
+
+		run( str( 'give %s minecraft:experience_bottle', player))
+	)
+);


### PR DESCRIPTION
Shift right-click on an enchanting table with an empty glass bottle and get a bottle o' enchanting. Average xp gain from bottles is 7, so I set the cost for bottling at 8.