### PR TITLE
Add support for trader llamas to `no_useless_llamas`

### DIFF
--- a/programs/survival/no_useless_llamas.sc
+++ b/programs/survival/no_useless_llamas.sc
@@ -9,7 +9,7 @@ _set_max_llama_storage(llama) -> (
 
 // detect when a player clicks a llama with a chest
 __on_player_interacts_with_entity(p, entity, hand) -> (
-    if(entity~'type'=='llama' && p~'holds':0 == 'chest',
+    if(entity~'type'~'llama' && p~'holds':0 == 'chest',
         _set_max_llama_storage(entity);
     );
 );


### PR DESCRIPTION
Turns out llama's and trader_llama's are different entities types.  