### PR TITLE
Use python's highlighter for libraries as well

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.sc linguist-language=Python
+*.scl linguist-language=Python


### PR DESCRIPTION
Currently only `.sc` files are highlighted. This makes `.scl` files be highlighted as well, given there's some coming in other PRs.