### PR TITLE
Properly setting clear weather in sleep_ignore_fake_players.sc

### DIFF
--- a/programs/survival/sleep_ignore_fake_players.sc
+++ b/programs/survival/sleep_ignore_fake_players.sc
@@ -17,7 +17,7 @@ in_dimension('overworld',
             global_allPlayerSleep = false;
             l = day_time() + 24000;
             day_time(l - l % 24000);
-            run('weather clear');
+            weather('clear', round(rand(0xFFFFFFFF))
         );
     );
 

--- a/programs/survival/sleep_ignore_fake_players.sc
+++ b/programs/survival/sleep_ignore_fake_players.sc
@@ -17,7 +17,7 @@ in_dimension('overworld',
             global_allPlayerSleep = false;
             l = day_time() + 24000;
             day_time(l - l % 24000);
-            if(weather('rain')>0, weather('clear', round(rand(0xFFFFFFFF)))
+            if(weather('rain')>0, weather('clear', round(rand(0x7FFFFFFF)))
         );
     );
 

--- a/programs/survival/sleep_ignore_fake_players.sc
+++ b/programs/survival/sleep_ignore_fake_players.sc
@@ -17,7 +17,8 @@ in_dimension('overworld',
             global_allPlayerSleep = false;
             l = day_time() + 24000;
             day_time(l - l % 24000);
-            if(weather('rain')>0, weather('clear', round(rand(0x7FFFFFFF))))
+            // doing this also sets rain and thunder to 0 because of scarpet impl, exactly what vanilla does when sleeping (from ServerWorld in yarn)
+            if (weather('rain') > 0, weather('clear', 0))
         );
     );
 

--- a/programs/survival/sleep_ignore_fake_players.sc
+++ b/programs/survival/sleep_ignore_fake_players.sc
@@ -17,7 +17,7 @@ in_dimension('overworld',
             global_allPlayerSleep = false;
             l = day_time() + 24000;
             day_time(l - l % 24000);
-            if(weather('rain')>0, weather('clear', round(rand(0x7FFFFFFF)))
+            if(weather('rain')>0, weather('clear', round(rand(0x7FFFFFFF))))
         );
     );
 

--- a/programs/survival/sleep_ignore_fake_players.sc
+++ b/programs/survival/sleep_ignore_fake_players.sc
@@ -17,7 +17,7 @@ in_dimension('overworld',
             global_allPlayerSleep = false;
             l = day_time() + 24000;
             day_time(l - l % 24000);
-            weather('clear', round(rand(0xFFFFFFFF))
+            if(weather('rain')>0, weather('clear', round(rand(0xFFFFFFFF)))
         );
     );
 


### PR DESCRIPTION
Fixes #241 
Using `weather('clear', round(rand(0x7FFFFFFF))` instead of `run('weather clear')` which always does 5 minutes (or 6000 ticks)