### PR TITLE
Fix deprecated usage in `item_holding_mobs_despawn`

### DIFF
--- a/programs/survival/item_holding_mobs_despawn.sc
+++ b/programs/survival/item_holding_mobs_despawn.sc
@@ -8,7 +8,7 @@ __config() -> {
 };
 
 entity_load_handler('monster', 
-    _(e) -> entity_event(e, 'on_tick', 
+    _(e, new) -> entity_event(e, 'on_tick', 
         _(e) -> ( 
             if(e ~ 'persistence' && e ~ 'holds' && ! e ~ 'custom_name', 
                 modify(e, 'persistence', false)


### PR DESCRIPTION
Fixes #358.

Also removes the `rule` suffix in the name to prevent confusion with it being a Carpet rule, though let me know if I should revert that. It has no `README` entry so it doesn't need to be updated (adding missing entries to readme can be fixed later).