### PR TITLE
Use air block above traced block to draw and color light level numbers

### DIFF
--- a/programs/survival/light_level_overlay.sc
+++ b/programs/survival/light_level_overlay.sc
@@ -89,7 +89,7 @@ schedule_overlay_new()->(
             if(block!=null,
                 pos = pos(block);
                 if(valid_spawnable(block) && air(pos_offset(pos, 'up')) && air(pos_offset(pos, 'up', 2)),
-                    [x, y, z] = pos;
+                    [x, y, z] = pos_offset(pos, 'up');
                     print(pos);
                     batch += [
                         'label', global_refresh_rate, 
@@ -97,7 +97,7 @@ schedule_overlay_new()->(
                         'text', block_light(x, y, z), 
                         'size', 20, 
                         'player', player, 
-                        'color', block_colour(block)
+                        'color', block_colour([x, y, z])
                     ]
                 )
             )


### PR DESCRIPTION
Line 92: shift the position to analyze up one block to...
Line 96: ...print the label on top of the block, not in the block
Line 97: ...get the light on top of the block, not in the block
Line 100: ...set the text color, again, based on the light on top of the block, not in the block

Upon further review, I might just dm suggestions since I don't know what I thought making a pull would do except, well, make one in the scarpet repo. Whoops!