### PR TITLE
Add AFK Display app

### DIFF
--- a/programs/survival/README.md
+++ b/programs/survival/README.md
@@ -3,6 +3,12 @@ Various scripts that modify various game elements, often replicating popular mod
 
 ## Survival scarpet apps in alphabetical order with creator:
 
+### [afk_display.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/afk_display.sc):
+#### By akaikagaribi
+	Grays out a player's name if they're not moving for 3 minutes (configurable).
+	The functionality of this script is identical to that of Vanilla Tweaks' AFK Display datapack, but it saves
+	what team a player was on before moving them to the AFK team, and puts them back in that team when they return.
+
 ### [angel_block.sc](https://github.com/gnembon/scarpet/blob/master/programs/survival/angel_block.sc):
 #### By "Pegasus Epsilon" <pegasus@pimpninjas.org>
 	Reimplementation of Angel Blocks from RandomThings mod in scarpet 1.4.
@@ -443,4 +449,5 @@ Various scripts that modify various game elements, often replicating popular mod
 	Xendergo
 	ch-yx
 	Crec0
+	akaikagaribi
 	(Many more hopefully!)

--- a/programs/survival/afk_display.sc
+++ b/programs/survival/afk_display.sc
@@ -1,0 +1,52 @@
+__config()->{
+    'scope'->'global',
+    'stay_loaded'->true
+};
+
+global_teams = read_file('teams.json', 'json');
+if(global_teams == null, global_teams = write_file('teams.json', 'json', {}); global_teams = read_file('teams.json', 'json'));
+
+// Change these values to your liking
+global_afk_prefix = '';
+global_afk_suffix = '';
+global_afk_timeout = 180; // seconds
+
+if(scoreboard('afkX') == null, scoreboard_add('afkX'));
+if(scoreboard('afkY') == null, scoreboard_add('afkY'));
+if(scoreboard('afkZ') == null, scoreboard_add('afkZ'));
+if(scoreboard('afkScore') == null, scoreboard_add('afkScore'));
+if(team_list('afk_players') == null,
+    team_add('afk_players');
+    team_property('afk_players', 'color', 'gray');
+    team_property('afk_players', 'prefix', global_afk_prefix);
+    team_property('afk_players', 'suffix', global_afk_suffix);
+);
+
+// To run this only each second
+global_tick = 0;
+__on_tick()->(
+    if((global_tick + 1) % 20 != 0, global_tick += 1; return(), global_tick = 0);
+    for(player('*'),
+        //run('say ' + global_teams:0);
+        if(and(
+                scoreboard('afkX', _) == scoreboard('afkX', _, _~'pos':0),
+                scoreboard('afkY', _) == scoreboard('afkY', _, _~'pos':1),
+                scoreboard('afkZ', _) == scoreboard('afkZ', _, _~'pos':2);
+            ),
+            scoreboard('afkScore', _, scoreboard('afkScore', _) + 1),
+            scoreboard('afkScore', _, 0);
+        );
+        if(scoreboard('afkScore', _) >= global_afk_timeout,
+            if(_~'team' == 'afk_players', continue());
+            global_teams:_ = _~'team';
+            write_file('teams.json', 'json', global_teams);
+            team_add('afk_players', _),
+
+            if(_~'team' != 'afk_players', continue());
+            if(global_teams:_, 
+                team_add(global_teams:_, _),
+                team_leave(_);
+            );
+        );
+    );
+);

--- a/programs/survival/afk_display.sc
+++ b/programs/survival/afk_display.sc
@@ -27,7 +27,6 @@ global_tick = 0;
 __on_tick()->(
     if((global_tick + 1) % 20 != 0, global_tick += 1; return(), global_tick = 0);
     for(player('*'),
-        //run('say ' + global_teams:0);
         if(and(
                 scoreboard('afkX', _) == scoreboard('afkX', _, _~'pos':0),
                 scoreboard('afkY', _) == scoreboard('afkY', _, _~'pos':1),


### PR DESCRIPTION
Grays out a player's name if they're not moving for 3 minutes (configurable).
The functionality of this script is identical to that of Vanilla Tweaks' AFK Display datapack, but it saves what team a player was on before moving them to the AFK team, and puts them back in that team when they return.

We discovered that thing with AFK Display datapack when we started using teams, so I decided to write my own version in scarpet and publish it, because it may be useful for other people.