### PR TITLE
pos update / tp interference workaround

### DIFF
--- a/programs/survival/cam.sc
+++ b/programs/survival/cam.sc
@@ -117,9 +117,10 @@ __store_player_takeoff_params(player) ->
 
 __restore_player_params(player, config) ->
 (
-   run('execute in minecraft:'+config:'dimension'+' run tp @s ~ ~ ~');
+   [x, y, z] = config:'pos';
+   run('execute in minecraft:'+config:'dimension'+' run tp @s '+x+' '+y+' '+z);
    modify(player, 'gamemode', 'survival');
-   for(l('pos', 'motion', 'yaw', 'pitch'), modify(player, _, config:_));
+   for(l('motion', 'yaw', 'pitch'), modify(player, _, config:_));
    for (config:'effects',
       modify(player, 'effect', _:'name', _:'duration', _:'amplifier')
    );


### PR DESCRIPTION
In 1.20.4 carpet it seems that a /tp command will override any entity pos update done in the same execution regardless of the order of the tp and pos update.

As a workaround update the position of the player in the world switching /tp instead of first switching worlds with a /tp and then position by a pos update.

This fixes #377