### PR TITLE
Fix shulkerboxes.sc for minecraft 1.20.4

### DIFF
--- a/programs/survival/shulkerboxes.sc
+++ b/programs/survival/shulkerboxes.sc
@@ -135,7 +135,7 @@ __add_item_to_vacuum_sboxes(player, search_item, refill_count, search_tag, do_ch
             if ( shulker_item ~ 'shulker_box$' 
                   && scount == 1 
                   && (nametag = shulker_tag:'display.Name') != null
-                  && lower(parse_nbt(nametag):'text') ~ 'vacuum'
+                  && lower(parse_nbt(nametag)) ~ 'vacuum'
                   && (items = shulker_tag:'BlockEntityTag.Items[]') != null ,
                // well, not sure why nbt query for singleton lists return that element, not a list
                // but that's a Mojang thing
@@ -285,7 +285,7 @@ __swap_stack(player, slot, previous_item, item, count, tag) ->
          if ( shulker_item ~ 'shulker_box$' 
                && scount == 1 
                && (nametag = shulker_tag:'display.Name') != null
-               && (shulker_type = lower(parse_nbt(nametag):'text') ~ '(restock|swap)\\s+(same|keep|next|random|first)')
+               && (shulker_type = lower(parse_nbt(nametag)) ~ '(restock|swap)\\s+(same|keep|next|random|first)')
                && ([action_type, idx_choice] = shulker_type; (action_type!='restock' || count == 0 ) )
                && (shulker_stacks = shulker_tag:'BlockEntityTag.Items[]') != null ,
             if (type(shulker_stacks)=='nbt', shulker_stacks = [shulker_stacks]);


### PR DESCRIPTION
the result of `parse_nbt` cannot be accessed with `:'text'` anymore

I tested with the following versions, and the change to the app appears backward compatible:
| Version | without PR | with PR |
|---------|--------------|---------|
| 1.20.4+carpet/1.4.128 |❌(script has no effect)|✅|
| 1.19.4+carpet/1.4.101 |✅|✅|
| 1.16.5+carpet/1.4.44 |✅|✅| 
| 1.15.2+carpet/1.4.8 |❌(script has syntax error)|❔| 