### PR TITLE
Added creative mode error message to cam.sc

### DIFF
--- a/programs/survival/cam.sc
+++ b/programs/survival/cam.sc
@@ -59,6 +59,8 @@ __command() ->
             display_title(p, 'actionbar', format('y Entered camera mode'));
          )
       ));
+   , current_gamemode == 'creative',
+      display_title(p, 'actionbar', format('r You must be in survival mode to use camera mode'));
    );
    null
 );


### PR DESCRIPTION
Fixes #318 by displaying an error message if you try to use the command while in creative mode. The message might not be perfect, feel free to comment on it
![creative](https://github.com/gnembon/scarpet/assets/71465541/1aefc555-1681-4b4b-961f-97c28e1db0f4)
