### PR TITLE
Fix spellbook.sc give command not giving a book.

### DIFF
--- a/programs/utilities/spellbook.sc
+++ b/programs/utilities/spellbook.sc
@@ -408,7 +408,7 @@ give_book(name) -> (
   book = _read_book(name);
   p = player();
   _print_message(p, 
-    run(str('/give %s written_book%s', query(p, 'command_name'), _render_book_nbt(book))):1
+    run(str('/give %s written_book[written_book_content=%s]', query(p, 'command_name'), _render_book_nbt(book))):1
   );
 );
 


### PR DESCRIPTION
The vanilla /give command syntax changed. Running "/spellbook [book] give" results in no book and "[]" printed in chat.

Tested fix on 1.20.6.