### PR TITLE
Fix `fakeplayer_inv_editor.sc` for 1.21+

### DIFF
--- a/programs/survival/fakeplayer_inv_editor.sc
+++ b/programs/survival/fakeplayer_inv_editor.sc
@@ -2,7 +2,7 @@ __config()->{
     'scope'->'global',
     'stay_loaded'->true,
     'requires' -> {
-        'carpet' -> '>=1.4.57'
+        'carpet' -> '>=1.4.173'
     }
 };
 create_datapack('invupd', 

--- a/programs/survival/fakeplayer_inv_editor.sc
+++ b/programs/survival/fakeplayer_inv_editor.sc
@@ -29,6 +29,8 @@ create_datapack('invupd',
     }
 );
 global_nope=nbt('{nope:nopeChYx'+rand(1)+'nope}');
+global_nope_barrier=nbt('{id:"minecraft:barrier",components:{custom_data:'+global_nope+'}}');
+global_nope_structure_void=nbt('{id:"minecraft:structure_void",components:{custom_data:'+global_nope+'}}');
 
 global_slotmap=[[-1,7],[-2,1],[-3,2],[-4,3],[-5,4],...map(range(9),[_,45+_]),...map(range(27),[9+_,18+_])];
 
@@ -58,7 +60,7 @@ __on_player_interacts_with_entity(creativeplayer, fakeplayer, hand)->(
             run('player ' + fakeplayer + ' hotbar ' + (data:'slot'-8))
             // END FIX
         );
-        if(inventory_get(screen, data:'slot'):2==global_nope,
+        if(inventory_get(screen, data:'slot'):2:'components':'minecraft:custom_data' == global_nope,
             return('cancel')
         );
         if(action=='slot_update' && 0<=data:'slot' && data:'slot'<54,
@@ -68,8 +70,8 @@ __on_player_interacts_with_entity(creativeplayer, fakeplayer, hand)->(
 
     global_fakeplayersscreen:fakeplayer=screen;
 
-    loop(54,inventory_set(screen,_, 1, 'minecraft:structure_void',global_nope));
-    inventory_set(screen,fakeplayer~'selected_slot'+9, 1, 'minecraft:barrier',global_nope);
+    loop(54,inventory_set(screen,_, 1, 'minecraft:structure_void',global_nope_structure_void));
+    inventory_set(screen,fakeplayer~'selected_slot'+9, 1, 'minecraft:barrier',global_nope_barrier);
     playertoscreen(fakeplayer,screen)
 );
 
@@ -117,8 +119,8 @@ __fakeplayer_switches_slot(fakeplayer, from, to)->(
 // END FIX
     screen=global_fakeplayersscreen:fakeplayer;
     if(screen,(
-        inventory_set(screen,from+9, 1, 'minecraft:structure_void',global_nope);
-        inventory_set(screen,to  +9, 1, 'minecraft:barrier',global_nope);
+        inventory_set(screen,from+9, 1, 'minecraft:structure_void',global_nope_structure_void);
+        inventory_set(screen,to  +9, 1, 'minecraft:barrier',global_nope_barrier);
     ))
 );
 


### PR DESCRIPTION
As of 1.21.5 and Carpet 1.4.169, `fakeplayer_inv_editor.sc` will throw `NullPointerException` when calling `inventory_set()` in various places within the script. It seems that the NBT tag argument that got passed into `inventory_set()` causes this issue. Upon further investigation, my current conclusion is:

1. the NBT tag argument must also include the id of the item
2. custom data should now be placed in the `components.custom_data` tag, otherwise it would be lost

To address the two observations:
1. Barrier and structure void items for this script now have their own version of NBT tags
2. The custom tag is now added and checked in `components.custom_data`. It is possible that this change breaks compatibility to older version, most likely before 1.21 snapshot 24w19a where this tag is added (https://minecraft.wiki/w/Java_Edition_24w19a)