### PR TITLE
keepalive.sc supporting multiple fake-players and flight saving

### DIFF
--- a/programs/utilities/keepalive.sc
+++ b/programs/utilities/keepalive.sc
@@ -1,21 +1,59 @@
 // re-logs fake players upon server restart
 // must need to place it directly in the world scripts folder
 
-__config() -> {'scope' -> 'global'};
+__config() -> {
+	requires -> {
+		'minecraft' -> '>=1.8', // spectator was not a thing prior to 1.8
+	},
+	'scope' -> 'global'
+};
 
+__on_connect(e) -> (
+	// forcing the fake-players that were spawned in spectator back into creative to retain flight per their data
+	if(e:'gm' == 'creative' && e:'fly' == 1,
+		sleep(50); // the direct delay is needed to force it back into the proper gamemode. it cannot for the life of it do so at the exact same moment and requires the delay.
+		for([str('gamemode %s %s', e:'gm', e:'name')],
+			logger('warn', _);
+			run(_);
+		);
+	);
+);
+
+__on_player_connects(player) -> (
+	data = load_app_data();
+	if (data && data:'players',
+		data = parse_nbt(data:'players');
+
+		player_name = player()~'name';
+
+		for (data,
+			// we're detecting if the player connecting is a fake-player, thus guaranteeing that the player entity object exists and can be used
+			if (_:'name' == player_name,
+				task('__on_connect', _)
+			);
+		);
+	);
+);
+
+	
 __spawn_players() -> (
-   data = load_app_data();
-   if (data && data:'players',
-      data = parse_nbt(data:'players');
-      for (data,
-         for([str('player %s spawn at %f %f %f facing %f %f in %s',
-                  _:'name', _:'x', _:'y', _:'z', _:'yaw', _:'pitch', _:'dim'),
-              str('gamemode %s %s', _:'gm', _:'name')],
-            logger('warn', _);
-            run(_);
-         );
-         modify(player(_:'name'), 'flying', _:'fly')
-      )
+   	data = load_app_data();
+   	if (data && data:'players',
+    	data = parse_nbt(data:'players');
+	   	for (data,
+			if (_:'gm' == 'creative' && _:'fly' == 1,
+				// spawning creative fake-players in spectator to force the flying state as using modify throws an error due to potential race conditions
+				for([str('player %s spawn at %f %f %f facing %f %f in %s in spectator', _:'name', _:'x', _:'y', _:'z', _:'yaw', _:'pitch', _:'dim')],
+					logger('warn', _);
+					run(_);
+				);
+			, _:'gm' != 'creative',
+				for([str('player %s spawn at %f %f %f facing %f %f in %s in %s',_:'name', _:'x', _:'y', _:'z', _:'yaw', _:'pitch', _:'dim', _:'gm')],
+					logger('warn', _);
+					run(_);
+				);
+			);
+	   );
    );
 );
 

--- a/programs/utilities/keepalive.sc
+++ b/programs/utilities/keepalive.sc
@@ -26,20 +26,16 @@ __on_player_connects(player) -> (
 	)
 );
 
-__spawn_players() -> (
+__on_server_starts() -> (
    data = load_app_data();
    if (data && data:'players',
     	data = parse_nbt(data:'players');
 		
-	   for (data,
+	   	for (data,
 			global_cached_players:str(_:'name') = _;
 			run(str('player %s spawn at %f %f %f facing %f %f in %s in %s', _:'name', _:'x', _:'y', _:'z', _:'yaw', _:'pitch', _:'dim', _:'gm'))
 		);
    );
-);
-
-__on_server_starts() -> (
-  task('__spawn_players');
 );
 
 __on_server_shuts_down() -> (

--- a/programs/utilities/keepalive.sc
+++ b/programs/utilities/keepalive.sc
@@ -16,8 +16,8 @@ __on_player_connects(player) -> (
 
 	if (has(global_cached_players, player_name),
       e = global_cached_players:player_name;
-     if(e:'gm' == 'creative' && e:'fly' == 1,
-      // scheduling the modification at the end to ensure the entity was created properly and resetting it back to the intended gamemode
+      if(e:'gm' == 'creative' && e:'fly' == 1,
+      // scheduling the modification at the end to ensure the entity was created properly and setting it to the intended state
          schedule(0, _(e) -> (modify(player(e:'name'), 'flying', e:'fly')), e);
       );
 	)

--- a/programs/utilities/keepalive.sc
+++ b/programs/utilities/keepalive.sc
@@ -13,55 +13,55 @@ __config() -> {
 __on_player_connects(player) -> (
 	player_name = player()~'name';
 
-   if (has(global_cached_players, player_name),
-      e = global_cached_players:player_name;
-      if(e:'gm' == 'creative' && e:'fly' == 1,
-      // scheduling the modification at the end to ensure the entity was created properly and setting it to the intended state
-         schedule(0, _(e) -> (modify(player(e:'name'), 'flying', e:'fly')), e);
-      );
-   )
+	if (has(global_cached_players, player_name),
+		e = global_cached_players:player_name;
+		if(e:'gm' == 'creative' && e:'fly' == 1,
+		// scheduling the modification at the end to ensure the entity was created properly and setting it to the intended state
+			schedule(0, _(e) -> (modify(player(e:'name'), 'flying', e:'fly')), e);
+		);
+	)
 );
 
 __on_player_disconnects(player, reason) -> (
-   player_name = player()~'name';
+	player_name = player()~'name';
 
-   if (has(global_cached_players, player_name),
-      entry = global_cached_players:str(player_name);
-      global_cached_players:str(player_name) = null;
-   );
+	if (has(global_cached_players, player_name),
+		entry = global_cached_players:str(player_name);
+		global_cached_players:str(player_name) = null;
+	);
 );
 
 __on_server_starts() -> (
-   data = load_app_data();
-   
-   if (data && data:'players',
-    	data = parse_nbt(data:'players');
-	   for (data,
+	data = load_app_data();
+	
+	if (data && data:'players',
+		data = parse_nbt(data:'players');
+		for (data,
 			global_cached_players:str(_:'name') = _;
 			run(str('player %s spawn at %f %f %f facing %f %f in %s in %s', _:'name', _:'x', _:'y', _:'z', _:'yaw', _:'pitch', _:'dim', _:'gm'))
 		);
-   );
+	);
 );
 
 __on_server_shuts_down() -> (
-   data = nbt('{players:[]}');
-   saved = [];
+	data = nbt('{players:[]}');
+	saved = [];
 
-   for (filter(player('all'), _~'player_type' == 'fake'),
-      pdata = nbt('{}');
-      pdata:'name' = _~'name';
-      pdata:'dim' = _~'dimension';
-      pdata:'x' = _~'x';
-      pdata:'y' = _~'y';
-      pdata:'z' = _~'z';
-      pdata:'yaw' = _~'yaw';
-      pdata:'pitch' = _~'pitch';
-      pdata:'gm' = _~'gamemode';
-      pdata:'fly' = _~'flying';
-      put(data, 'players', pdata, -1);
-      saved += _~'name';
-   );
-   
-   store_app_data(data);
-   if (saved, logger('warn', 'saved '+saved+' for next startup'));
+	for (filter(player('all'), _~'player_type' == 'fake'),
+		pdata = nbt('{}');
+		pdata:'name' = _~'name';
+		pdata:'dim' = _~'dimension';
+		pdata:'x' = _~'x';
+		pdata:'y' = _~'y';
+		pdata:'z' = _~'z';
+		pdata:'yaw' = _~'yaw';
+		pdata:'pitch' = _~'pitch';
+		pdata:'gm' = _~'gamemode';
+		pdata:'fly' = _~'flying';
+		put(data, 'players', pdata, -1);
+		saved += _~'name';
+	);
+
+	store_app_data(data);
+	if (saved, logger('warn', 'saved '+saved+' for next startup'));
 );

--- a/programs/utilities/keepalive.sc
+++ b/programs/utilities/keepalive.sc
@@ -27,11 +27,11 @@ __on_player_connects(player) -> (
 );
 
 __spawn_players() -> (
-   	data = load_app_data();
-   	if (data && data:'players',
+   data = load_app_data();
+   if (data && data:'players',
     	data = parse_nbt(data:'players');
 		
-	   	for (data,
+	   for (data,
 			global_cached_players:str(_:'name') = _;
 			run(str('player %s spawn at %f %f %f facing %f %f in %s in %s', _:'name', _:'x', _:'y', _:'z', _:'yaw', _:'pitch', _:'dim', _:'gm'))
 		);

--- a/programs/utilities/keepalive.sc
+++ b/programs/utilities/keepalive.sc
@@ -4,9 +4,6 @@
 global_cached_players = {};
 
 __config() -> {
-	requires -> {
-		'minecraft' -> '>=1.8', // spectator was not a thing prior to 1.8
-	},
 	'scope' -> 'global'
 };
 

--- a/programs/utilities/keepalive.sc
+++ b/programs/utilities/keepalive.sc
@@ -10,19 +10,16 @@ __config() -> {
 	'scope' -> 'global'
 };
 
-__on_connect(e) -> (
-	// forcing the fake-players that were spawned in spectator back into creative to retain flight per their data
-	if(e:'gm' == 'creative' && e:'fly' == 1,
-	// scheduling the modification at the end to ensure the entity was created properly and resetting it back to the intended gamemode
-		schedule(0, _(e) -> (modify(player(e:'name'), 'flying', e:'fly')), e);
-	);
-);
 
 __on_player_connects(player) -> (
 	player_name = player()~'name';
 
 	if (has(global_cached_players, player_name),
-		task('__on_connect', global_cached_players:player_name)
+      e = global_cached_players:player_name;
+     if(e:'gm' == 'creative' && e:'fly' == 1,
+      // scheduling the modification at the end to ensure the entity was created properly and resetting it back to the intended gamemode
+         schedule(0, _(e) -> (modify(player(e:'name'), 'flying', e:'fly')), e);
+      );
 	)
 );
 

--- a/programs/utilities/keepalive.sc
+++ b/programs/utilities/keepalive.sc
@@ -31,8 +31,6 @@ __on_player_disconnects(player, reason) -> (
 
    if (has(global_cached_players, player_name),
       entry = global_cached_players:str(player_name);
-      logger('warn', str('%s %s', entry:'gm', entry:'fly'));
-
       global_cached_players:str(player_name) = null;
    );
 );

--- a/programs/utilities/keepalive.sc
+++ b/programs/utilities/keepalive.sc
@@ -1,6 +1,8 @@
 // re-logs fake players upon server restart
 // must need to place it directly in the world scripts folder
 
+global_cached_players = {};
+
 __config() -> {
 	requires -> {
 		'minecraft' -> '>=1.8', // spectator was not a thing prior to 1.8
@@ -11,49 +13,35 @@ __config() -> {
 __on_connect(e) -> (
 	// forcing the fake-players that were spawned in spectator back into creative to retain flight per their data
 	if(e:'gm' == 'creative' && e:'fly' == 1,
-		sleep(50); // the direct delay is needed to force it back into the proper gamemode. it cannot for the life of it do so at the exact same moment and requires the delay.
-		for([str('gamemode %s %s', e:'gm', e:'name')],
-			logger('warn', _);
-			run(_);
-		);
+	// scheduling the modification at the end to ensure the entity was created properly and resetting it back to the intended gamemode
+		schedule(0, _(e) -> (modify(player(e:'name'), 'gamemode', e:'gm')), e);
 	);
 );
 
 __on_player_connects(player) -> (
-	data = load_app_data();
-	if (data && data:'players',
-		data = parse_nbt(data:'players');
+	player_name = player()~'name';
 
-		player_name = player()~'name';
-
-		for (data,
-			// we're detecting if the player connecting is a fake-player, thus guaranteeing that the player entity object exists and can be used
-			if (_:'name' == player_name,
-				task('__on_connect', _)
-			);
-		);
-	);
+	if (has(global_cached_players, player_name),
+		task('__on_connect', global_cached_players:player_name)
+	)
 );
 
-	
 __spawn_players() -> (
    	data = load_app_data();
    	if (data && data:'players',
     	data = parse_nbt(data:'players');
+		
 	   	for (data,
+			global_cached_players:str(_:'name') = _;
+
+			gamemode = _:'gm';
 			if (_:'gm' == 'creative' && _:'fly' == 1,
 				// spawning creative fake-players in spectator to force the flying state as using modify throws an error due to potential race conditions
-				for([str('player %s spawn at %f %f %f facing %f %f in %s in spectator', _:'name', _:'x', _:'y', _:'z', _:'yaw', _:'pitch', _:'dim')],
-					logger('warn', _);
-					run(_);
-				);
-			, _:'gm' != 'creative',
-				for([str('player %s spawn at %f %f %f facing %f %f in %s in %s',_:'name', _:'x', _:'y', _:'z', _:'yaw', _:'pitch', _:'dim', _:'gm')],
-					logger('warn', _);
-					run(_);
-				);
+				gamemode = 'spectator'
 			);
-	   );
+			
+			run(str('player %s spawn at %f %f %f facing %f %f in %s in %s', _:'name', _:'x', _:'y', _:'z', _:'yaw', _:'pitch', _:'dim', gamemode))
+		);
    );
 );
 

--- a/programs/utilities/keepalive.sc
+++ b/programs/utilities/keepalive.sc
@@ -26,6 +26,17 @@ __on_player_connects(player) -> (
 	)
 );
 
+__on_player_disconnects(player, reason) -> (
+	player_name = player()~'name';
+
+   if (has(global_cached_players, player_name),
+      entry = global_cached_players:str(player_name);
+      logger('warn', str('%s %s', entry:'gm', entry:'fly'));
+
+      global_cached_players:str(player_name) = null;
+   );
+);
+
 __on_server_starts() -> (
    data = load_app_data();
    if (data && data:'players',

--- a/programs/utilities/keepalive.sc
+++ b/programs/utilities/keepalive.sc
@@ -10,21 +10,20 @@ __config() -> {
 	'scope' -> 'global'
 };
 
-
 __on_player_connects(player) -> (
 	player_name = player()~'name';
 
-	if (has(global_cached_players, player_name),
+   if (has(global_cached_players, player_name),
       e = global_cached_players:player_name;
       if(e:'gm' == 'creative' && e:'fly' == 1,
       // scheduling the modification at the end to ensure the entity was created properly and setting it to the intended state
          schedule(0, _(e) -> (modify(player(e:'name'), 'flying', e:'fly')), e);
       );
-	)
+   )
 );
 
 __on_player_disconnects(player, reason) -> (
-	player_name = player()~'name';
+   player_name = player()~'name';
 
    if (has(global_cached_players, player_name),
       entry = global_cached_players:str(player_name);
@@ -34,10 +33,10 @@ __on_player_disconnects(player, reason) -> (
 
 __on_server_starts() -> (
    data = load_app_data();
+   
    if (data && data:'players',
     	data = parse_nbt(data:'players');
-		
-	   	for (data,
+	   for (data,
 			global_cached_players:str(_:'name') = _;
 			run(str('player %s spawn at %f %f %f facing %f %f in %s in %s', _:'name', _:'x', _:'y', _:'z', _:'yaw', _:'pitch', _:'dim', _:'gm'))
 		);
@@ -47,6 +46,7 @@ __on_server_starts() -> (
 __on_server_shuts_down() -> (
    data = nbt('{players:[]}');
    saved = [];
+
    for (filter(player('all'), _~'player_type' == 'fake'),
       pdata = nbt('{}');
       pdata:'name' = _~'name';
@@ -61,6 +61,7 @@ __on_server_shuts_down() -> (
       put(data, 'players', pdata, -1);
       saved += _~'name';
    );
+   
    store_app_data(data);
    if (saved, logger('warn', 'saved '+saved+' for next startup'));
 );

--- a/programs/utilities/keepalive.sc
+++ b/programs/utilities/keepalive.sc
@@ -14,7 +14,7 @@ __on_connect(e) -> (
 	// forcing the fake-players that were spawned in spectator back into creative to retain flight per their data
 	if(e:'gm' == 'creative' && e:'fly' == 1,
 	// scheduling the modification at the end to ensure the entity was created properly and resetting it back to the intended gamemode
-		schedule(0, _(e) -> (modify(player(e:'name'), 'gamemode', e:'gm')), e);
+		schedule(0, _(e) -> (modify(player(e:'name'), 'flying', e:'fly')), e);
 	);
 );
 
@@ -33,14 +33,7 @@ __spawn_players() -> (
 		
 	   	for (data,
 			global_cached_players:str(_:'name') = _;
-
-			gamemode = _:'gm';
-			if (_:'gm' == 'creative' && _:'fly' == 1,
-				// spawning creative fake-players in spectator to force the flying state as using modify throws an error due to potential race conditions
-				gamemode = 'spectator'
-			);
-			
-			run(str('player %s spawn at %f %f %f facing %f %f in %s in %s', _:'name', _:'x', _:'y', _:'z', _:'yaw', _:'pitch', _:'dim', gamemode))
+			run(str('player %s spawn at %f %f %f facing %f %f in %s in %s', _:'name', _:'x', _:'y', _:'z', _:'yaw', _:'pitch', _:'dim', _:'gm'))
 		);
    );
 );

--- a/programs/utilities/keepalive.sc
+++ b/programs/utilities/keepalive.sc
@@ -13,7 +13,7 @@ __on_player_connects(player) -> (
 	if (has(global_cached_players, player_name),
 		e = global_cached_players:player_name;
 		if(e:'gm' == 'creative' && e:'fly' == 1,
-		// scheduling the modification at the end to ensure the entity was created properly and setting it to the intended state
+			// scheduling the modification at the end to ensure the entity was created properly and setting it to the intended state
 			schedule(0, _(e) -> (modify(player(e:'name'), 'flying', e:'fly')), e);
 		);
 	)
@@ -23,7 +23,6 @@ __on_player_disconnects(player, reason) -> (
 	player_name = player()~'name';
 
 	if (has(global_cached_players, player_name),
-		entry = global_cached_players:str(player_name);
 		global_cached_players:str(player_name) = null;
 	);
 );


### PR DESCRIPTION
a lot of this could probably be simplified, however in minecraft version 1.21.4 ive noticed that `modify(e, state, value)` doesnt directly do something when applied during the exact timeframe as `on_player_connects` runs and throws an error inside of `__spawn_players` due to attempting to modify a non-existing entity, a potential race condition happening here.

These changes function from my testing 100% of the time while retaining positional accuracy  on minecraft v1.21.4, tested with 2 fake-players flying at high altitude.

im currently unable to test it on prior versions or 1.21.5 due to time constraints so external testing on other version would be greatly appreciated.

Cheers!

fixes #408 fixes #388