### PR TITLE
Fixed fakeplayer inv editor equipment slots

### DIFF
--- a/programs/survival/fakeplayer_inv_editor.sc
+++ b/programs/survival/fakeplayer_inv_editor.sc
@@ -29,6 +29,8 @@ create_datapack('invupd',
     }
 );
 global_nope=nbt('{nope:nopeChYx'+rand(1)+'nope}');
+global_nope_barrier=nbt('{id:"minecraft:barrier",components:{custom_data:'+global_nope+'}}');
+global_nope_structure_void=nbt('{id:"minecraft:structure_void",components:{custom_data:'+global_nope+'}}');
 
 global_slotmap=[[-1,7],[-2,1],[-3,2],[-4,3],[-5,4],...map(range(9),[_,45+_]),...map(range(27),[9+_,18+_])];
 
@@ -58,7 +60,7 @@ __on_player_interacts_with_entity(creativeplayer, fakeplayer, hand)->(
             run('player ' + fakeplayer + ' hotbar ' + (data:'slot'-8))
             // END FIX
         );
-        if(inventory_get(screen, data:'slot'):2==global_nope,
+        if(inventory_get(screen, data:'slot'):2:'components':'minecraft:custom_data' == global_nope,
             return('cancel')
         );
         if(action=='slot_update' && 0<=data:'slot' && data:'slot'<54,
@@ -68,8 +70,8 @@ __on_player_interacts_with_entity(creativeplayer, fakeplayer, hand)->(
 
     global_fakeplayersscreen:fakeplayer=screen;
 
-    loop(54,inventory_set(screen,_, 1, 'minecraft:structure_void',global_nope));
-    inventory_set(screen,fakeplayer~'selected_slot'+9, 1, 'minecraft:barrier',global_nope);
+    loop(54,inventory_set(screen,_, 1, 'minecraft:structure_void',global_nope_structure_void));
+    inventory_set(screen,fakeplayer~'selected_slot'+9, 1, 'minecraft:barrier',global_nope_barrier);
     playertoscreen(fakeplayer,screen)
 );
 
@@ -117,8 +119,8 @@ __fakeplayer_switches_slot(fakeplayer, from, to)->(
 // END FIX
     screen=global_fakeplayersscreen:fakeplayer;
     if(screen,(
-        inventory_set(screen,from+9, 1, 'minecraft:structure_void',global_nope);
-        inventory_set(screen,to  +9, 1, 'minecraft:barrier',global_nope);
+        inventory_set(screen,from+9, 1, 'minecraft:structure_void',global_nope_structure_void);
+        inventory_set(screen,to  +9, 1, 'minecraft:barrier',global_nope_barrier);
     ))
 );
 

--- a/programs/survival/fakeplayer_inv_editor.sc
+++ b/programs/survival/fakeplayer_inv_editor.sc
@@ -2,15 +2,16 @@ __config()->{
     'scope'->'global',
     'stay_loaded'->true,
     'requires' -> {
-        'carpet' -> '>=1.4.57'
+        'carpet' -> '>=1.4.57',
+        'minecraft' -> '>=1.21',
     }
 };
-create_datapack('invupd', 
+create_datapack('invupd',
     {
         'readme.txt' -> ['this data pack is created by scarpet','please dont touch it'],
         'data' -> {
             'chyx' ->{
-                'advancements'->{
+                'advancement'->{
                     'xd.json'-> {
                         'rewards' -> {'function' -> 'chyx:invupd'},
                         'criteria' -> {
@@ -21,7 +22,7 @@ create_datapack('invupd',
                         }
                     }
                 },
-                'functions'->{
+                'function'->{
                     'invupd.mcfunction' -> 'script run signal_event(\'invupd\', null, player())\nadvancement revoke @s only chyx:xd'
                 }
             }
@@ -62,7 +63,7 @@ __on_player_interacts_with_entity(creativeplayer, fakeplayer, hand)->(
         ));
         if(data:'slot'==null,return());
         if(action=='pickup' && 9<=data:'slot' && data:'slot'<18,
-            // CARPET BUG 1.4.66 - Modify not working for fake players: 
+            // CARPET BUG 1.4.66 - Modify not working for fake players:
             // modify(fakeplayer,'selected_slot', data:'slot'-9);
             // FIX:
             run('player ' + fakeplayer + ' hotbar ' + (data:'slot'-8))
@@ -107,7 +108,7 @@ handle_event('invupd',_(fakeplayer)->(
     if(screen,playertoscreen(fakeplayer,screen));
 ));
 
-// CARPET BUG 1.4.66 - Event not working for fake players: 
+// CARPET BUG 1.4.66 - Event not working for fake players:
 // __on_player_switches_slot(fakeplayer, from, to)-> if(player ~ 'player_type' == 'fake',
 // FIX:
 global_fakeplayers_selected_slot = {};

--- a/programs/survival/fakeplayer_inv_editor.sc
+++ b/programs/survival/fakeplayer_inv_editor.sc
@@ -32,7 +32,15 @@ global_nope=nbt('{nope:nopeChYx'+rand(1)+'nope}');
 global_nope_barrier=nbt('{id:"minecraft:barrier",components:{custom_data:'+global_nope+'}}');
 global_nope_structure_void=nbt('{id:"minecraft:structure_void",components:{custom_data:'+global_nope+'}}');
 
-global_slotmap=[[-1,7],[-2,1],[-3,2],[-4,3],[-5,4],...map(range(9),[_,45+_]),...map(range(27),[9+_,18+_])];
+global_slotmap=[
+    {'inventory' -> 'equipment', 'inventory_slot' -> 5, 'screen' -> 7}, // offhand
+    {'inventory' -> 'equipment', 'inventory_slot' -> 4, 'screen' -> 1}, // head
+    {'inventory' -> 'equipment', 'inventory_slot' -> 3, 'screen' -> 2}, // chest
+    {'inventory' -> 'equipment', 'inventory_slot' -> 2, 'screen' -> 3}, // legs
+    {'inventory' -> 'equipment', 'inventory_slot' -> 1, 'screen' -> 4}, // feet
+    ...map(range(9),{'inventory' -> null, 'inventory_slot' -> _, 'screen' -> 45+_}), // hotbar
+    ...map(range(27),{'inventory' -> null, 'inventory_slot' -> 9+_, 'screen' -> 18+_}) // inventory
+];
 
 
 global_fakeplayersscreen={};
@@ -77,22 +85,20 @@ __on_player_interacts_with_entity(creativeplayer, fakeplayer, hand)->(
 
 playertoscreen(fakeplayer,screen)->(
     for(global_slotmap,(
-        [playerslot,screenslot]=_;
-        itemtup=inventory_get(fakeplayer, playerslot);
+        itemtup=inventory_get(_:'inventory', fakeplayer, _:'inventory_slot');
         if(itemtup==null,itemtup=['apple',0,null]);
         [item,count,nbt]=itemtup;
         
-        inventory_set(screen,screenslot, count, item, nbt);
+        inventory_set(screen, _:'screen', count, item, nbt);
     ))
 );
 screentoplayer(fakeplayer,screen)->(
     for(global_slotmap,(
-        [playerslot,screenslot]=_;
-        itemtup=inventory_get(screen, screenslot);
+        itemtup=inventory_get(screen, _:'screen');
         if(itemtup==null,itemtup=['apple',0,null]);
         [item,count,nbt]=itemtup;
         
-        inventory_set(fakeplayer,playerslot, count, item, nbt);
+        inventory_set(_:'inventory', fakeplayer, _:'inventory_slot', count, item, nbt);
     ));
 );
 


### PR DESCRIPTION
This PR is based on the fixes in #420, so that should be merged first.

Fixes the armor and offhand slot not working by using `inventory_set('equipment', p, ..)`.
Also renames the datapack folder names `advancements` and `functions` to be `advancement` and `function`, as changed in 24w21a (1.21).
However, since advancements currently do not work for fake player, the updating of the screen from the player still does not work until fake players work with advancements, or another method for detecting inventory changes is used.