### PR TITLE
fakeplayer_inv_editor.sc: Fixed incorrect armor and offhand slot assignment for mc 26.1

### DIFF
--- a/programs/survival/fakeplayer_inv_editor.sc
+++ b/programs/survival/fakeplayer_inv_editor.sc
@@ -32,7 +32,7 @@ global_nope=nbt('{nope:nopeChYx'+rand(1)+'nope}');
 global_nope_barrier=nbt('{id:"minecraft:barrier",components:{custom_data:'+global_nope+'}}');
 global_nope_structure_void=nbt('{id:"minecraft:structure_void",components:{custom_data:'+global_nope+'}}');
 
-global_slotmap=[[-1,7],[-2,1],[-3,2],[-4,3],[-5,4],...map(range(9),[_,45+_]),...map(range(27),[9+_,18+_])];
+global_slotmap=[[-3,7],[-7,1],[-6,2],[-5,3],[-4,4],...map(range(9),[_,45+_]),...map(range(27),[9+_,18+_])];
 
 
 global_fakeplayersscreen={};


### PR DESCRIPTION
This PR just contains a small change to the `fakeplayer_inv_editor.sc`. In the latest version at time of writing, the armor and offhand slots are no longer assigned correctly. So filling the intended interface slots of the fake player would not make it equip armor or put an item in the offhand. 

This PR fixes the issue by slightly changing the slot assignments in the `global_slotmap`. All slots can now be accessed properly through the interface. 

(Tested on mc26.1.2 and fabric-carpet-26.1+v260402)